### PR TITLE
[feat] signup_이메일로 회원가입 기능 구현 #21

### DIFF
--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { useRef } from 'react';
 import { useEffect } from 'react';
-// import axios from 'axios';
+import { axiosPrivate } from '../../apis/axios';
 
+// 이메일 유효성 체크
 const EMAIL_REGEX =
   /([\w-.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
-const PWD_REGEX = /^[0-9]{6,12}$/;
+const PWD_REGEX = /^[a-zA-Z0-9]{6,}$/;
 
 const Signup = () => {
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState(''); //
   const [validEmail, setValidEmail] = useState(false);
   const [errEmailMsg, setErrEmailMsg] = useState('');
   const [password, setPassword] = useState('');
@@ -19,9 +20,24 @@ const Signup = () => {
   // 버튼 활성화 조건 처리
   const canNext = validEmail && validPassword;
 
+  const emailCheck = async () => {
+    if (!validEmail) return console.log('서버 요청 안함');
+
+    const { data } = await axiosPrivate.post(
+      `/user/emailvalid/`,
+      JSON.stringify({
+        user: {
+          email,
+        },
+      }),
+    );
+    console.log(data.message);
+    setErrEmailMsg(data.message);
+  };
+
   // input focus
   useEffect(() => {
-    inputRef.current.focus();
+    if (inputRef.current !== null) inputRef.current.focus();
   }, []);
 
   // 다음 버튼 활성화
@@ -30,24 +46,23 @@ const Signup = () => {
     setValidEmail(result);
 
     // email.length가 0인 경우
-    // reesult가 true인 경우
-    // email.lengthrk 0이면서 result인 경우
-    if (!email.length || result)
-      setErrEmailMsg(''); // email.length가 0이거나  경우
-    else setErrEmailMsg('*올바른 이메일 형식이 아닙니다'); // email.length가 0 아니면서 result가 false인 경우
+    // result가 true인 경우
+    // email.length가 0이면서 result인 경우
+    if (!email.length || result) {
+      setErrEmailMsg(''); // email.length가 0이거나 result값이 있는 경우
+    } else {
+      setErrEmailMsg('잘못된 이메일 형식입니다.'); // email.length가 0 아니면서 result가 false인 경우
+    }
   }, [email]);
 
   useEffect(() => {
     const result = PWD_REGEX.test(password);
-    console.log(result);
     setValidPassword(result);
 
-    if (password.length && !result)
-      setErrPasswordMsg('*비밀번호는 6자 이상이여야 합니다.');
-    else setErrPasswordMsg('');
+    if (password.length && !result) {
+      setErrPasswordMsg('비밀번호는 6자 이상이어야 합니다.');
+    } else setErrPasswordMsg('');
   }, [password]);
-
-  console.log(errEmailMsg);
 
   return (
     <form>
@@ -59,6 +74,7 @@ const Signup = () => {
         placeholder='이메일 주소를 입력해 주세요.'
         value={email}
         onChange={(e) => setEmail(e.target.value)}
+        onBlur={emailCheck}
         ref={inputRef}
       />
       {errEmailMsg && <p>{errEmailMsg}</p>}

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -1,10 +1,21 @@
 import React, { useState } from 'react';
+import { useRef } from 'react';
+import { useEffect } from 'react';
+// import axios from 'axios';
 
 const Signup = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const inputRef = useRef();
 
-  console.log(email, password);
+  // email 유효성 검사 체크
+  useEffect(() => {
+    // input focus
+    inputRef.current.focus();
+
+    // email 정규식
+    //   const regexEmail = '';
+  }, []);
 
   return (
     <form>
@@ -16,9 +27,10 @@ const Signup = () => {
         placeholder='이메일 주소를 입력해 주세요.'
         value={email}
         onChange={(e) => setEmail(e.target.value)}
+        ref={inputRef}
       />
+      <p>이미 가입된 이메일 주소입니다.</p>
       <br />
-
       <label htmlFor='pwd'>비밀번호</label>
       <br />
       <input
@@ -28,9 +40,11 @@ const Signup = () => {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
+      <p>비밀번호는 6자 이상이여야 합니다.</p>
       <br />
-
-      <button>다음</button>
+      <button>다음</button> <br />
+      <br />
+      <span>입력된 값: {password}</span>
     </form>
   );
 };

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -3,19 +3,51 @@ import { useRef } from 'react';
 import { useEffect } from 'react';
 // import axios from 'axios';
 
+const EMAIL_REGEX =
+  /([\w-.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
+const PWD_REGEX = /^[0-9]{6,12}$/;
+
 const Signup = () => {
   const [email, setEmail] = useState('');
+  const [validEmail, setValidEmail] = useState(false);
+  const [errEmailMsg, setErrEmailMsg] = useState('');
   const [password, setPassword] = useState('');
+  const [validPassword, setValidPassword] = useState(false);
+  const [errPasswordlMsg, setErrPasswordMsg] = useState('');
   const inputRef = useRef();
 
-  // email 유효성 검사 체크
-  useEffect(() => {
-    // input focus
-    inputRef.current.focus();
+  // 버튼 활성화 조건 처리
+  const canNext = validEmail && validPassword;
 
-    // email 정규식
-    //   const regexEmail = '';
+  // input focus
+  useEffect(() => {
+    inputRef.current.focus();
   }, []);
+
+  // 다음 버튼 활성화
+  useEffect(() => {
+    const result = EMAIL_REGEX.test(email);
+    setValidEmail(result);
+
+    // email.length가 0인 경우
+    // reesult가 true인 경우
+    // email.lengthrk 0이면서 result인 경우
+    if (!email.length || result)
+      setErrEmailMsg(''); // email.length가 0이거나  경우
+    else setErrEmailMsg('*올바른 이메일 형식이 아닙니다'); // email.length가 0 아니면서 result가 false인 경우
+  }, [email]);
+
+  useEffect(() => {
+    const result = PWD_REGEX.test(password);
+    console.log(result);
+    setValidPassword(result);
+
+    if (password.length && !result)
+      setErrPasswordMsg('*비밀번호는 6자 이상이여야 합니다.');
+    else setErrPasswordMsg('');
+  }, [password]);
+
+  console.log(errEmailMsg);
 
   return (
     <form>
@@ -29,7 +61,7 @@ const Signup = () => {
         onChange={(e) => setEmail(e.target.value)}
         ref={inputRef}
       />
-      <p>이미 가입된 이메일 주소입니다.</p>
+      {errEmailMsg && <p>{errEmailMsg}</p>}
       <br />
       <label htmlFor='pwd'>비밀번호</label>
       <br />
@@ -40,11 +72,11 @@ const Signup = () => {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <p>비밀번호는 6자 이상이여야 합니다.</p>
+      {errPasswordlMsg && <p>{errPasswordlMsg}</p>}
       <br />
-      <button>다음</button> <br />
+      <button disabled={!canNext}>다음</button> <br />
       <br />
-      <span>입력된 값: {password}</span>
+      <span>입력된 값: {email}</span>
     </form>
   );
 };

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+const Signup = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  console.log(email, password);
+
+  return (
+    <form>
+      <label htmlFor='email'>이메일</label>
+      <br />
+      <input
+        id='email'
+        type='text'
+        placeholder='이메일 주소를 입력해 주세요.'
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <br />
+
+      <label htmlFor='pwd'>비밀번호</label>
+      <br />
+      <input
+        id='pwd'
+        type='password'
+        placeholder='비밀번호를 설정해 주세요.'
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <br />
+
+      <button>다음</button>
+    </form>
+  );
+};
+
+export default Signup;

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
-import { useRef } from 'react';
-import { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { axiosPrivate } from '../../apis/axios';
 
 // 이메일 유효성 체크
@@ -9,6 +8,7 @@ const EMAIL_REGEX =
 const PWD_REGEX = /^[a-zA-Z0-9]{6,}$/;
 
 const Signup = () => {
+  const navigate = useNavigate();
   const [email, setEmail] = useState(''); //
   const [validEmail, setValidEmail] = useState(false);
   const [errEmailMsg, setErrEmailMsg] = useState('');
@@ -21,7 +21,7 @@ const Signup = () => {
   const canNext = validEmail && validPassword;
 
   const emailCheck = async () => {
-    if (!validEmail) return console.log('서버 요청 안함');
+    if (!validEmail) return;
 
     const { data } = await axiosPrivate.post(
       `/user/emailvalid/`,
@@ -31,8 +31,20 @@ const Signup = () => {
         },
       }),
     );
-    console.log(data.message);
+    if (data.message !== '사용 가능한 이메일 입니다.') setValidEmail(false);
     setErrEmailMsg(data.message);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!validEmail || errPasswordlMsg) return;
+
+    navigate('/signup/profile', {
+      state: {
+        email,
+        password,
+      },
+    });
   };
 
   // input focus
@@ -65,7 +77,7 @@ const Signup = () => {
   }, [password]);
 
   return (
-    <form>
+    <form onSubmit={handleSubmit}>
       <label htmlFor='email'>이메일</label>
       <br />
       <input

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const SignupProfile = () => {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  console.log(state);
+
+  useEffect(() => {
+    if (!state?.email || !state?.password) navigate('/signup');
+  }, []);
+
+  return <div>index</div>;
+};
+
+export default SignupProfile;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -9,6 +9,7 @@ import Profile from '../pages/Profile';
 import Public from '../pages/Public';
 import Search from '../pages/Search';
 import Signup from '../pages/Signup';
+import SignupProfile from '../pages/SignupProfile';
 
 const Router = () => {
   return (
@@ -17,7 +18,11 @@ const Router = () => {
         <Route path='/' element={<Layout />}>
           <Route index element={<Public />} />
           <Route path='login' element={<Login />} />
-          <Route path='signup' element={<Signup />} />
+
+          <Route path='signup'>
+            <Route index element={<Signup />} />
+            <Route path='profile' element={<SignupProfile />} />
+          </Route>
 
           <Route element={<RequireAuth />}>
             <Route element={<Navbar />}>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -8,6 +8,7 @@ import Login from '../pages/Login';
 import Profile from '../pages/Profile';
 import Public from '../pages/Public';
 import Search from '../pages/Search';
+import Signup from '../pages/Signup';
 
 const Router = () => {
   return (
@@ -16,6 +17,7 @@ const Router = () => {
         <Route path='/' element={<Layout />}>
           <Route index element={<Public />} />
           <Route path='login' element={<Login />} />
+          <Route path='signup' element={<Signup />} />
 
           <Route element={<RequireAuth />}>
             <Route element={<Navbar />}>
@@ -37,4 +39,3 @@ const Router = () => {
 };
 
 export default Router;
-


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [x] 신규 기능 추가 : 이메일로 회원가입 기능 구현 (회원가입 2페이지 중 첫번째 페이지)
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 디자인 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
 - 회원가입 입력 폼 생성
 - 입력 정보 유효성 검사 처리
 - 이메일 중복 데이터 검사 처리
 - 프로필 정보 입력 페이지로 이동 처리

## 💻 작업내용
<img width="189" alt="image" src="https://user-images.githubusercontent.com/104605709/208038157-819e1bb4-c0e5-4e7a-9a2d-9bdbe4ed43de.png">
<img width="215" alt="image" src="https://user-images.githubusercontent.com/104605709/208038377-966d1e1f-8949-4949-ae91-04cd7f05f42f.png">


## 😉 전달사항
- 회원가입 페이지 하단에 찍어둔 입력된 값 텍스트는 디자인 작업하면서 지울 예정입니다!
