### PR TITLE
[design] search_페이지 검색리스트 UI 구현

### DIFF
--- a/src/components/common/Header/ChatHeader/style.js
+++ b/src/components/common/Header/ChatHeader/style.js
@@ -10,10 +10,10 @@ export const LeftIcon = styled.img.attrs({
 
 export const MiddleIcon = styled.img.attrs({
     src: ChatHeaderText,
-    alt: '뒤로가기',
+    alt: '채팅상대',
   })``;
 
 export const RightIcon = styled.img.attrs({
   src: ModalIcon,
-  alt: '업로드',
+  alt: '모달창',
 })``;

--- a/src/components/search/SearchList/index.jsx
+++ b/src/components/search/SearchList/index.jsx
@@ -1,16 +1,22 @@
-import React from 'react'
+import React from 'react';
+import * as S from './style';
 
 const SearchList = ({ searchList }) => {
-  console.log(searchList);
-
   return (
-    <ul>
+    <S.SearchList>
       {searchList.map((item) => (
-        <li key={item._id}>
-           <p>{item.username}</p>
-        </li>
+        <S.StyledLink to={`/profile/${item.accountname}`} key={item._id}>
+          <S.SearchItem>
+            <S.UserImage alt="프로필" src={item.image}/>
+          
+            <S.UserInfo>
+              <S.UserName>{item.username}</S.UserName>
+              <S.AccountName>{item.accountname}</S.AccountName>
+            </S.UserInfo>
+          </S.SearchItem>
+        </S.StyledLink>
       ))}
-    </ul>
+    </S.SearchList>
   )
 }
 

--- a/src/components/search/SearchList/style.js
+++ b/src/components/search/SearchList/style.js
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+export const SearchList = styled.ul`
+  padding: 12px 16px;
+`;
+
+export const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: ${({ theme }) => theme.palette.black};
+`;
+
+export const SearchItem = styled.li`
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+`;
+
+export const UserImage = styled.img`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+  margin-left: 12px;
+`;
+
+export const UserName = styled.strong`
+  font-size: 14px;
+`;
+
+export const AccountName = styled.p`
+  font-size: 12px;
+  color: ${({ theme }) => theme.palette.mediumGray};
+`;


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [x] 신규 기능 추가 : 검색리스트 클릭시 해당 유저 프로필 페이지로 이동기능 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [x] 디자인 : search_페이지 검색리스트 UI 구현
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
- 검색리스트 클릭시 해당 유저 프로필 페이지로 이동기능 구현
- search_페이지 검색리스트 UI 구현

## 💻 작업내용

- 검색값 삽입시 리스트 UI 

<img width="419" alt="스크린샷 2022-12-16 오후 4 44 32" src="https://user-images.githubusercontent.com/111214565/208048732-4849c257-6323-4cd0-a41a-543137804cfc.png">


- 검색리스트 클릭 시 해당 유저 프로필 페이지로 이동

<img width="457" alt="스크린샷 2022-12-16 오후 4 46 03" src="https://user-images.githubusercontent.com/111214565/208048917-0d8b9a61-5227-4e1a-98cc-6453be3dbff1.png">


## 😉 전달사항