### PR TITLE
[feat] signup_프로필 설정 및 회원가입 처리 기능 구현 #44

### DIFF
--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -1,0 +1,162 @@
+import React, { useState, useEffect } from 'react';
+import { axiosImgUpload, axiosPrivate } from '../../../apis/axios';
+
+const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
+// eslint-disable-next-line
+const ACCOUNTNAME_REGEX = /^[a-z0-9\.\_]{2,15}$/;
+
+const UserProfileForm = ({
+  setCanSignup,
+  username,
+  setUsername,
+  accountname,
+  setAccountname,
+  intro,
+  setIntro,
+  profileImg,
+  setProfileImg,
+}) => {
+  const [validUserName, setValidUserName] = useState(false);
+  const [errUserNameMsg, setErrUserNameMsg] = useState('');
+  const [validAccountName, setValidAccountName] = useState(false);
+  const [validDupAccountName, setValidDupAccountName] = useState(false);
+  const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
+
+  const handleImgUpload = async (e) => {
+    if (!e.target.files[0]) return;
+
+    let form = new FormData();
+    form.append('image', e.target.files[0]);
+    // 서버에 파일 전달
+    const {
+      data: { filename },
+    } = await axiosImgUpload.post('/image/uploadfile', form);
+
+    setProfileImg(`https://mandarin.api.weniv.co.kr/${filename}`);
+  };
+
+  // 계정 ID 중복확인
+  const handleDupAccountName = async () => {
+    if (validAccountName === true) {
+      try {
+        const { data } = await axiosPrivate.post(
+          `/user/accountnamevalid`,
+          JSON.stringify({
+            user: {
+              accountname: accountname,
+            },
+          }),
+        );
+        if (data.message === '사용 가능한 계정ID 입니다.') {
+          setValidDupAccountName(true);
+          setErrAccountNameMsg(data.message);
+        } else if (data.message === '잘못된 접근입니다.') {
+          setValidDupAccountName(false);
+          setErrAccountNameMsg('');
+        } else {
+          setValidDupAccountName(false);
+          setErrAccountNameMsg(data.message);
+        }
+      } catch (error) {
+        console.error('err');
+      }
+    } else {
+      setValidDupAccountName(false);
+      return;
+    }
+  };
+
+  // 계정 ID 유효성 체크
+  useEffect(() => {
+    setValidDupAccountName(false);
+    const result = ACCOUNTNAME_REGEX.test(accountname);
+
+    if (accountname.length && !result) {
+      setErrAccountNameMsg(
+        '영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능합니다.',
+      );
+      setValidAccountName(false);
+    } else {
+      setErrAccountNameMsg('');
+      setValidAccountName(true);
+    }
+  }, [accountname]);
+
+  // 사용자 이름 유효성 체크
+  useEffect(() => {
+    const result = USERNAME_REGEX.test(username);
+    setValidUserName(result);
+
+    if (username.length && !result) {
+      setErrUserNameMsg('2~10자의 한글,영어,숫자만 사용 가능합니다.');
+      setValidAccountName(false);
+    } else {
+      setErrUserNameMsg('');
+      setValidAccountName(true);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    setCanSignup(validUserName && validAccountName & validDupAccountName);
+  }, [validUserName, validAccountName, validDupAccountName]);
+
+  // 회원가입처리
+
+  return (
+    <>
+      <form>
+        <div>
+          <label htmlFor='profileImg' style={{ cursor: 'pointer' }}>
+            <img
+              src={profileImg}
+              alt='프로필 사진'
+              width='110px'
+              height='110px'
+            />
+          </label>
+          <input
+            id='profileImg'
+            type='file'
+            accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
+            onChange={handleImgUpload}
+            style={{ display: 'none' }}
+          />
+        </div>
+        <div>
+          <label htmlFor='userName'>사용자 이름</label> <br />
+          <input
+            id='userName'
+            placeholder='2~10자의 한글,영어,숫자만 사용 가능'
+            maxLength='10'
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {errUserNameMsg && <p>{errUserNameMsg}</p>}
+        </div>
+        <div>
+          <label htmlFor='accountName'>계정 ID</label> <br />
+          <input
+            id='accountName'
+            placeholder='영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능'
+            maxLength='15'
+            value={accountname}
+            onChange={(e) => setAccountname(e.target.value)}
+            onBlur={handleDupAccountName}
+          />
+          {errAccountNameMsg && <p>{errAccountNameMsg}</p>}
+        </div>
+        <div>
+          <label htmlFor='introduce'>소개</label> <br />
+          <input
+            id='introduce'
+            placeholder='간단한 자기소개를 적어주세요!'
+            value={intro}
+            onChange={(e) => setIntro(e.target.value)}
+          />
+        </div>
+      </form>
+    </>
+  );
+};
+
+export default UserProfileForm;

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -21,7 +21,6 @@ const Signup = () => {
 
   // 버튼 활성화 조건 처리
   const canNext = validRegEmail && validPassword && validDupEmail;
-  console.log(validDupEmail);
 
   // 이메일 중복검사
   const handleDupEmail = async () => {

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -24,8 +24,8 @@ const Signup = () => {
   console.log(validDupEmail);
 
   // 이메일 중복검사
-  const emailCheck = async () => {
-    if (EMAIL_REGEX.test(email)) {
+  const handleDupEmail = async () => {
+    if (validRegEmail === true) {
       try {
         const { data } = await axiosPrivate.post(
           `/user/emailvalid/`,
@@ -110,7 +110,7 @@ const Signup = () => {
               placeholder='이메일 주소를 입력해 주세요.'
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              onBlur={emailCheck}
+              onBlur={handleDupEmail}
               ref={inputRef}
             />
             {errEmailMsg && (
@@ -134,7 +134,7 @@ const Signup = () => {
 
           <S.NextButton
             disabled={!canNext}
-            onClick={emailCheck}
+            onClick={handleDupEmail}
             style={{ background: canNext ? '#495573' : '#abb9d6' }}
           >
             다음

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -62,7 +62,7 @@ const Signup = () => {
       setErrEmailMsg('');
       setValidRegEmail(false);
     } else {
-      setErrEmailMsg('잘못된 이메일 형식입니다.');
+      setErrEmailMsg('이메일 형식을 맞춰주세요.');
       setValidRegEmail(false);
     }
   }, [email]);

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -10,8 +10,9 @@ const PWD_REGEX = /^[a-zA-Z0-9]{6,}$/;
 
 const Signup = () => {
   const navigate = useNavigate();
-  const [email, setEmail] = useState(''); //
-  const [validEmail, setValidEmail] = useState(false);
+  const [email, setEmail] = useState('');
+  const [validRegEmail, setValidRegEmail] = useState(false);
+  const [validDupEmail, setValidDupEmail] = useState(false);
   const [errEmailMsg, setErrEmailMsg] = useState('');
   const [password, setPassword] = useState('');
   const [validPassword, setValidPassword] = useState(false);
@@ -19,63 +20,81 @@ const Signup = () => {
   const inputRef = useRef();
 
   // 버튼 활성화 조건 처리
-  const canNext = validEmail && validPassword;
+  const canNext = validRegEmail && validPassword && validDupEmail;
+  console.log(validDupEmail);
 
+  // 이메일 중복검사
   const emailCheck = async () => {
-    if (!validEmail) return;
-
-    const { data } = await axiosPrivate.post(
-      `/user/emailvalid/`,
-      JSON.stringify({
-        user: {
-          email,
-        },
-      }),
-    );
-    if (data.message !== '사용 가능한 이메일 입니다.') setValidEmail(false);
-    setErrEmailMsg(data.message);
+    if (EMAIL_REGEX.test(email)) {
+      try {
+        const { data } = await axiosPrivate.post(
+          `/user/emailvalid/`,
+          JSON.stringify({
+            user: {
+              email,
+            },
+          }),
+        );
+        if (data.message === '사용 가능한 이메일 입니다.') {
+          setValidDupEmail(true);
+          setErrEmailMsg(data.message);
+        } else {
+          setValidDupEmail(false);
+          setErrEmailMsg(data.message);
+        }
+      } catch (error) {
+        console.error('err');
+      }
+    } else {
+      setValidDupEmail(false);
+      return;
+    }
   };
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!validEmail || errPasswordlMsg) return;
+  // 이메일 정규식 체크
+  useEffect(() => {
+    setValidDupEmail(false);
+    const result = EMAIL_REGEX.test(email);
+    if (email.length && result) {
+      setErrEmailMsg('');
+      setValidRegEmail(true);
+    } else if (email === '') {
+      setErrEmailMsg('');
+      setValidRegEmail(false);
+    } else {
+      setErrEmailMsg('잘못된 이메일 형식입니다.');
+      setValidRegEmail(false);
+    }
+  }, [email]);
 
-    navigate('/signup/profile', {
-      state: {
-        email,
-        password,
-      },
-    });
-  };
+  // 비밀번호 정규식 체크
+  useEffect(() => {
+    const result = PWD_REGEX.test(password);
+    if (password.length && !result) {
+      setErrPasswordMsg('비밀번호는 6자 이상이어야 합니다.');
+      setValidPassword(false);
+    } else {
+      setErrPasswordMsg('');
+      setValidPassword(true);
+    }
+  }, [password]);
 
-  // input focus
   useEffect(() => {
     if (inputRef.current !== null) inputRef.current.focus();
   }, []);
 
-  // 다음 버튼 활성화
-  useEffect(() => {
-    const result = EMAIL_REGEX.test(email);
-    setValidEmail(result);
-
-    // email.length가 0인 경우
-    // result가 true인 경우
-    // email.length가 0이면서 result인 경우
-    if (!email.length || result) {
-      setErrEmailMsg(''); // email.length가 0이거나 result값이 있는 경우
-    } else {
-      setErrEmailMsg('잘못된 이메일 형식입니다.'); // email.length가 0 아니면서 result가 false인 경우
+  // 페이지 이동
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (canNext) {
+      navigate('/signup/profile', {
+        state: {
+          email,
+          password,
+        },
+      });
     }
-  }, [email]);
-
-  useEffect(() => {
-    const result = PWD_REGEX.test(password);
-    setValidPassword(result);
-
-    if (password.length && !result) {
-      setErrPasswordMsg('비밀번호는 6자 이상이어야 합니다.');
-    } else setErrPasswordMsg('');
-  }, [password]);
+  };
 
   return (
     <>
@@ -94,7 +113,11 @@ const Signup = () => {
               onBlur={emailCheck}
               ref={inputRef}
             />
-            {errEmailMsg && <p>{errEmailMsg}</p>}
+            {errEmailMsg && (
+              <p style={{ color: validDupEmail ? '#495573' : '#EB7F5F' }}>
+                {errEmailMsg}
+              </p>
+            )}
           </S.InputWrapper>
 
           <S.InputWrapper length='30px'>
@@ -109,9 +132,9 @@ const Signup = () => {
             {errPasswordlMsg && <p>{errPasswordlMsg}</p>}
           </S.InputWrapper>
 
-          {/* <S.NextButton disabled={!canNext}>다음</S.NextButton> */}
           <S.NextButton
             disabled={!canNext}
+            onClick={emailCheck}
             style={{ background: canNext ? '#495573' : '#abb9d6' }}
           >
             다음

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -1,129 +1,39 @@
-import React, { useState, useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { axiosImgUpload, axiosPrivate } from '../../apis/axios';
-
-const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
-// eslint-disable-next-line
-const ACCOUNTNAME_REGEX = /^[a-z0-9\.\_]{2,15}$/;
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import UserProfileForm from '../../components/user/UserProfileForm';
+import { axiosPrivate } from '../../apis/axios';
 
 const SignupProfile = () => {
   const { state } = useLocation();
-  console.log(state);
   const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [accountname, setAccountname] = useState('');
+  const [intro, setIntro] = useState('');
   const [profileImg, setProfileImg] = useState(
     'https://mandarin.api.weniv.co.kr/1671431659709.png',
   );
-  const [userName, setUserName] = useState('');
-  const [validUserName, setValidUserName] = useState(false);
-  const [errUserNameMsg, setErrUserNameMsg] = useState('');
-  const [accountName, setAccountName] = useState('');
-  const [validAccountName, setValidAccountName] = useState(false);
-  const [validDupAccountName, setValidDupAccountName] = useState(false);
-  const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
-  const [intro, setIntro] = useState('');
+  const [canSignup, setCanSignup] = useState(false);
 
-  // 버튼 활성화 조건 처리
-  const canSignup = validUserName && validAccountName & validDupAccountName;
-
-  const handleImgUpload = async (e) => {
-    let form = new FormData();
-
-    if (e.target.files[0] === undefined) {
-      return;
-    } else {
-      form.append('image', e.target.files[0]);
-    }
-
-    // 서버에 파일 전달
-    const {
-      data: { filename },
-    } = await axiosImgUpload.post('/image/uploadfile', form);
-
-    setProfileImg(`https://mandarin.api.weniv.co.kr/${filename}`);
-  };
-
-  // 계정 ID 중복확인
-  const handleDupAccountName = async () => {
-    if (validAccountName === true) {
-      try {
-        const { data } = await axiosPrivate.post(
-          `/user/accountnamevalid`,
-          JSON.stringify({
-            user: {
-              accountname: accountName,
-            },
-          }),
-        );
-        if (data.message === '사용 가능한 계정ID 입니다.') {
-          setValidDupAccountName(true);
-          setErrAccountNameMsg(data.message);
-        } else if (data.message === '잘못된 접근입니다.') {
-          setValidDupAccountName(false);
-          setErrAccountNameMsg('');
-        } else {
-          setValidDupAccountName(false);
-          setErrAccountNameMsg(data.message);
-        }
-      } catch (error) {
-        console.error('err');
-      }
-    } else {
-      setValidDupAccountName(false);
-      return;
-    }
-  };
-
-  // 계정 ID 유효성 체크
   useEffect(() => {
-    setValidDupAccountName(false);
-    const result = ACCOUNTNAME_REGEX.test(accountName);
+    if (!state?.email || !state?.password) navigate('/signup');
+  }, []);
 
-    if (accountName.length && !result) {
-      setErrAccountNameMsg(
-        '영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능합니다.',
-      );
-      setValidAccountName(false);
-    } else {
-      setErrAccountNameMsg('');
-      setValidAccountName(true);
-    }
-  }, [accountName]);
-
-  // 사용자 이름 유효성 체크
-  useEffect(() => {
-    const result = USERNAME_REGEX.test(userName);
-    setValidUserName(result);
-
-    if (userName.length && !result) {
-      setErrUserNameMsg('2~10자의 한글,영어,숫자만 사용 가능합니다.');
-      setValidAccountName(false);
-    } else {
-      setErrUserNameMsg('');
-      setValidAccountName(true);
-    }
-  }, [userName]);
-
-  // 회원가입처리
   const handleUserSignup = async (e) => {
     e.preventDefault();
-    console.log(state.email, state.password);
-    console.log(profileImg, userName, accountName, intro);
-    if (!state?.email || !state?.password) navigate('/signup');
-    if (canSignup) {
-      await axiosPrivate.post(
-        '/user',
-        JSON.stringify({
-          user: {
-            username: userName,
-            email: state.email,
-            password: state.password,
-            accountname: accountName,
-            intro,
-            image: profileImg,
-          },
-        }),
-      );
-    }
+    if (!canSignup) return;
+    await axiosPrivate.post(
+      '/user',
+      JSON.stringify({
+        user: {
+          username,
+          email: state?.email,
+          password: state?.password,
+          accountname,
+          intro,
+          image: profileImg,
+        },
+      }),
+    );
     navigate('/login');
   };
 
@@ -132,58 +42,22 @@ const SignupProfile = () => {
       <section>
         <h1>프로필 설정</h1>
         <p>나중에 언제든지 변경할 수 있습니다.</p>
-        <form onSubmit={handleUserSignup}>
-          <div>
-            <label htmlFor='profileImg' style={{ cursor: 'pointer' }}>
-              <img
-                src={profileImg}
-                alt='프로필 사진'
-                width='110px'
-                height='110px'
-              />
-            </label>
-            <input
-              id='profileImg'
-              type='file'
-              accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
-              onChange={handleImgUpload}
-              style={{ display: 'none' }}
-            />
-          </div>
-          <div>
-            <label htmlFor='userName'>사용자 이름</label> <br />
-            <input
-              id='userName'
-              placeholder='2~10자의 한글,영어,숫자만 사용 가능'
-              maxLength='10'
-              value={userName}
-              onChange={(e) => setUserName(e.target.value)}
-            />
-            {errUserNameMsg && <p>{errUserNameMsg}</p>}
-          </div>
-          <div>
-            <label htmlFor='accountName'>계정 ID</label> <br />
-            <input
-              id='accountName'
-              placeholder='영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능'
-              maxLength='15'
-              value={accountName}
-              onChange={(e) => setAccountName(e.target.value)}
-              onBlur={handleDupAccountName}
-            />
-            {errAccountNameMsg && <p>{errAccountNameMsg}</p>}
-          </div>
-          <div>
-            <label htmlFor='introduce'>소개</label> <br />
-            <input
-              id='introduce'
-              placeholder='간단한 자기소개를 적어주세요!'
-              value={intro}
-              onChange={(e) => setIntro(e.target.value)}
-            />
-          </div>
-          <button disabled={!canSignup}>1n마켓 시작하기</button>
-        </form>
+        <UserProfileForm
+          canSignup={canSignup}
+          setCanSignup={setCanSignup}
+          handleUserSignup={handleUserSignup}
+          username={username}
+          setUsername={setUsername}
+          accountname={accountname}
+          setAccountname={setAccountname}
+          intro={intro}
+          setIntro={setIntro}
+          profileImg={profileImg}
+          setProfileImg={setProfileImg}
+        />
+        <button disabled={!canSignup} onClick={handleUserSignup}>
+          1n마켓 시작하기
+        </button>
       </section>
     </>
   );

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -1,9 +1,21 @@
 import React, { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { axiosImgUpload } from '../../apis/axios';
 
 const SignupProfile = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
+  console.log(state);
+
+  const handleImgUpload = async (e) => {
+    let form = new FormData();
+    form.append('image', e.target.files[0]);
+    console.log(e.target.files[0]);
+
+    // 서버에 파일 전달
+    const response = await axiosImgUpload.post('/image/uploadfile', form);
+    console.log(response);
+  };
 
   useEffect(() => {
     if (!state?.email || !state?.password) navigate('/signup');
@@ -16,10 +28,13 @@ const SignupProfile = () => {
         <p>나중에 언제든지 변경할 수 있습니다.</p>
         <form>
           <div>
-            <label htmlFor='profileImg'>
-              <img src='' />
-            </label>
-            <input id='profileImg' type='file' placeholder='파일등록' />
+            <label htmlFor='profileImg'>{/* <img src='' /> */}</label>
+            <input
+              id='profileImg'
+              type='file'
+              accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
+              onChange={handleImgUpload}
+            />
           </div>
           <div>
             <label htmlFor='userName'>사용자 이름</label> <br />

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -3,6 +3,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { axiosImgUpload } from '../../apis/axios';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
+// eslint-disable-next-line
+const ACCOUNTNAME_REGEX = /^(?=[a-z])[a-z0-9\.\_]{5,15}$/;
 
 const SignupProfile = () => {
   const { state } = useLocation();
@@ -11,9 +13,14 @@ const SignupProfile = () => {
     'https://mandarin.api.weniv.co.kr/1671431659709.png',
   );
   const [userName, setUserName] = useState('');
+  console.log('userName :' + !!userName);
   const [validUserName, setValidUserName] = useState('false');
   console.log(validUserName);
   const [errUserNameMsg, setErrUserNameMsg] = useState('');
+  const [accountName, setAccountName] = useState('');
+  const [validAccountName, setValidAccountName] = useState('false');
+  console.log(validAccountName);
+  const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
 
   const handleImgUpload = async (e) => {
     let form = new FormData();
@@ -38,12 +45,27 @@ const SignupProfile = () => {
     const result = USERNAME_REGEX.test(userName);
     setValidUserName(result);
 
-    if (!userName || result) {
+    if (userName.length && !result) {
+      setErrUserNameMsg('2~10자의 한글,영어,숫자만 사용 가능합니다.');
+    } else {
       setErrUserNameMsg('');
-    } else if (userName.length && !result) {
-      setErrUserNameMsg('2자~10자 이내여야 합니다.');
     }
   }, [userName]);
+
+  // 계정 id 유효성 체크
+  useEffect(() => {
+    const result = ACCOUNTNAME_REGEX.test(accountName);
+    setValidAccountName(result);
+    console.log('accountName: ' + result);
+
+    if (accountName.length && !result) {
+      setErrAccountNameMsg(
+        '5~15자 이내의 영문 소문자, 숫자와 특수문자 마침표(.), 밑줄(_)만 사용 가능합니다.',
+      );
+    } else {
+      setErrAccountNameMsg('');
+    }
+  }, [accountName]);
 
   return (
     <>
@@ -64,27 +86,32 @@ const SignupProfile = () => {
             />
           </div>
           <div>
-            <label htmlFor='userName'>사용자 이름</label> <br />
+            <label htmlFor='userName'>사용자 이름(필수)</label> <br />
             <input
               id='userName'
               placeholder='2~10자 이내여야 합니다.'
+              maxLength='10'
               value={userName}
               onChange={(e) => setUserName(e.target.value)}
             />
             {errUserNameMsg && <p>{errUserNameMsg}</p>}
           </div>
           <div>
-            <label htmlFor='accountId'>계정 ID</label> <br />
+            <label htmlFor='accountName'>계정 ID(필수)</label> <br />
             <input
-              id='accountId'
-              placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+              id='accountName'
+              placeholder='5~15자 이내의 영문 소문자, 숫자와 특수문자 마침표(.), 밑줄(_)만 사용 가능합니다.'
+              maxLength='15'
+              value={accountName}
+              onChange={(e) => setAccountName(e.target.value)}
             />
+            {errAccountNameMsg && <p>{errAccountNameMsg}</p>}
           </div>
           <div>
             <label htmlFor='introduce'>소개</label> <br />
             <input id='introduce' placeholder='자신에 대해 소개해 주세요!' />
           </div>
-          <button>1n마켓 시작하기</button>
+          <button disabled>1n마켓 시작하기</button>
         </form>
       </section>
     </>

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -4,10 +4,11 @@ import { axiosImgUpload, axiosPrivate } from '../../apis/axios';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
 // eslint-disable-next-line
-const ACCOUNTNAME_REGEX = /^[a-z0-9\.\_]{5,15}$/;
+const ACCOUNTNAME_REGEX = /^[a-z0-9\.\_]{2,15}$/;
 
 const SignupProfile = () => {
   const { state } = useLocation();
+  console.log(state);
   const navigate = useNavigate();
   const [profileImg, setProfileImg] = useState(
     'https://mandarin.api.weniv.co.kr/1671431659709.png',
@@ -15,10 +16,11 @@ const SignupProfile = () => {
   const [userName, setUserName] = useState('');
   const [validUserName, setValidUserName] = useState(false);
   const [errUserNameMsg, setErrUserNameMsg] = useState('');
-  const [accountname, setAccountname] = useState('');
+  const [accountName, setAccountName] = useState('');
   const [validAccountName, setValidAccountName] = useState(false);
   const [validDupAccountName, setValidDupAccountName] = useState(false);
   const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
+  const [intro, setIntro] = useState('');
 
   // 버튼 활성화 조건 처리
   const canSignup = validUserName && validAccountName & validDupAccountName;
@@ -41,14 +43,14 @@ const SignupProfile = () => {
   };
 
   // 계정 ID 중복확인
-  const accountNameCheck = async () => {
+  const handleDupAccountName = async () => {
     if (validAccountName === true) {
       try {
         const { data } = await axiosPrivate.post(
           `/user/accountnamevalid`,
           JSON.stringify({
             user: {
-              accountname,
+              accountname: accountName,
             },
           }),
         );
@@ -74,9 +76,9 @@ const SignupProfile = () => {
   // 계정 ID 유효성 체크
   useEffect(() => {
     setValidDupAccountName(false);
-    const result = ACCOUNTNAME_REGEX.test(accountname);
+    const result = ACCOUNTNAME_REGEX.test(accountName);
 
-    if (accountname.length && !result) {
+    if (accountName.length && !result) {
       setErrAccountNameMsg(
         '영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능합니다.',
       );
@@ -85,7 +87,7 @@ const SignupProfile = () => {
       setErrAccountNameMsg('');
       setValidAccountName(true);
     }
-  }, [accountname]);
+  }, [accountName]);
 
   // 사용자 이름 유효성 체크
   useEffect(() => {
@@ -101,16 +103,36 @@ const SignupProfile = () => {
     }
   }, [userName]);
 
-  useEffect(() => {
+  // 회원가입처리
+  const handleUserSignup = async (e) => {
+    e.preventDefault();
+    console.log(state.email, state.password);
+    console.log(profileImg, userName, accountName, intro);
     if (!state?.email || !state?.password) navigate('/signup');
-  }, []);
+    if (canSignup) {
+      await axiosPrivate.post(
+        '/user',
+        JSON.stringify({
+          user: {
+            username: userName,
+            email: state.email,
+            password: state.password,
+            accountname: accountName,
+            intro,
+            image: profileImg,
+          },
+        }),
+      );
+    }
+    navigate('/login');
+  };
 
   return (
     <>
       <section>
         <h1>프로필 설정</h1>
         <p>나중에 언제든지 변경할 수 있습니다.</p>
-        <form autoComplete='off'>
+        <form onSubmit={handleUserSignup}>
           <div>
             <label htmlFor='profileImg' style={{ cursor: 'pointer' }}>
               <img
@@ -145,15 +167,20 @@ const SignupProfile = () => {
               id='accountName'
               placeholder='영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능'
               maxLength='15'
-              value={accountname}
-              onChange={(e) => setAccountname(e.target.value)}
-              onBlur={accountNameCheck}
+              value={accountName}
+              onChange={(e) => setAccountName(e.target.value)}
+              onBlur={handleDupAccountName}
             />
             {errAccountNameMsg && <p>{errAccountNameMsg}</p>}
           </div>
           <div>
             <label htmlFor='introduce'>소개</label> <br />
-            <input id='introduce' placeholder='간단한 자기소개를 적어주세요!' />
+            <input
+              id='introduce'
+              placeholder='간단한 자기소개를 적어주세요!'
+              value={intro}
+              onChange={(e) => setIntro(e.target.value)}
+            />
           </div>
           <button disabled={!canSignup}>1n마켓 시작하기</button>
         </form>

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { axiosImgUpload } from '../../apis/axios';
+import { axiosImgUpload, axiosPrivate } from '../../apis/axios';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
 // eslint-disable-next-line
@@ -9,25 +9,29 @@ const ACCOUNTNAME_REGEX = /^(?=[a-z])[a-z0-9\.\_]{5,15}$/;
 const SignupProfile = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
-  const [profileImg, setProfileImg] = useState(
-    'https://mandarin.api.weniv.co.kr/1671431659709.png',
-  );
+  const [profileImg, setProfileImg] = useState('');
   const [userName, setUserName] = useState('');
-  console.log('userName :' + !!userName);
   const [validUserName, setValidUserName] = useState('false');
   const [errUserNameMsg, setErrUserNameMsg] = useState('');
-  const [accountName, setAccountName] = useState('');
+  const [accountname, setAccountname] = useState('');
   const [validAccountName, setValidAccountName] = useState('false');
   const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
 
   // 가입 버튼 활성화 처리
   const canSignup = validUserName && validAccountName;
 
+  if (profileImg === '') {
+    setProfileImg('https://mandarin.api.weniv.co.kr/1671431659709.png');
+  }
+
   const handleImgUpload = async (e) => {
     let form = new FormData();
 
-    form.append('image', e.target.files[0]);
-    if (e.target.files[0] === undefined) return;
+    if (e.target.files[0] === undefined) {
+      return;
+    } else {
+      form.append('image', e.target.files[0]);
+    }
 
     // 서버에 파일 전달
     const {
@@ -35,6 +39,22 @@ const SignupProfile = () => {
     } = await axiosImgUpload.post('/image/uploadfile', form);
 
     setProfileImg(`https://mandarin.api.weniv.co.kr/${filename}`);
+    console.log(profileImg);
+  };
+
+  // 계정 ID 중복확인
+  const accountNameCheck = async () => {
+    if (!validAccountName) return;
+
+    const res = await axiosPrivate.post(
+      `/user/accountnamevalid`,
+      JSON.stringify({
+        user: {
+          accountname,
+        },
+      }),
+    );
+    console.log(res);
   };
 
   useEffect(() => {
@@ -53,20 +73,19 @@ const SignupProfile = () => {
     }
   }, [userName]);
 
-  // 계정 id 유효성 체크
+  // 계정 ID 유효성 체크
   useEffect(() => {
-    const result = ACCOUNTNAME_REGEX.test(accountName);
+    const result = ACCOUNTNAME_REGEX.test(accountname);
     setValidAccountName(result);
-    console.log('accountName: ' + result);
 
-    if (accountName.length && !result) {
+    if (accountname.length && !result) {
       setErrAccountNameMsg(
-        '5~15자 이내의 영문 소문자, 숫자와 특수문자 마침표(.), 밑줄(_)만 사용 가능합니다.',
+        '영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능합니다.',
       );
     } else {
       setErrAccountNameMsg('');
     }
-  }, [accountName]);
+  }, [accountname]);
 
   return (
     <>
@@ -76,7 +95,12 @@ const SignupProfile = () => {
         <form autoComplete='off'>
           <div>
             <label htmlFor='profileImg' style={{ cursor: 'pointer' }}>
-              <img src={profileImg} alt='' width='110px' height='110px' />
+              <img
+                src={profileImg}
+                alt='프로필 사진'
+                width='110px'
+                height='110px'
+              />
             </label>
             <input
               id='profileImg'
@@ -87,10 +111,10 @@ const SignupProfile = () => {
             />
           </div>
           <div>
-            <label htmlFor='userName'>사용자 이름(필수)</label> <br />
+            <label htmlFor='userName'>사용자 이름</label> <br />
             <input
               id='userName'
-              placeholder='2~10자 이내여야 합니다.'
+              placeholder='2~10자의 한글,영어,숫자만 사용 가능'
               maxLength='10'
               value={userName}
               onChange={(e) => setUserName(e.target.value)}
@@ -98,19 +122,20 @@ const SignupProfile = () => {
             {errUserNameMsg && <p>{errUserNameMsg}</p>}
           </div>
           <div>
-            <label htmlFor='accountName'>계정 ID(필수)</label> <br />
+            <label htmlFor='accountName'>계정 ID</label> <br />
             <input
               id='accountName'
-              placeholder='5~15자 이내의 영문 소문자, 숫자와 특수문자 마침표(.), 밑줄(_)만 사용 가능합니다.'
+              placeholder='영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능'
               maxLength='15'
-              value={accountName}
-              onChange={(e) => setAccountName(e.target.value)}
+              value={accountname}
+              onChange={(e) => setAccountname(e.target.value)}
+              onBlur={accountNameCheck}
             />
             {errAccountNameMsg && <p>{errAccountNameMsg}</p>}
           </div>
           <div>
             <label htmlFor='introduce'>소개</label> <br />
-            <input id='introduce' placeholder='자신에 대해 소개해 주세요!' />
+            <input id='introduce' placeholder='간단한 자기소개를 적어주세요!' />
           </div>
           <button disabled={!canSignup}>1n마켓 시작하기</button>
         </form>

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -1,44 +1,77 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { axiosImgUpload } from '../../apis/axios';
+
+const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
 
 const SignupProfile = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
-  console.log(state);
+  const [profileImg, setProfileImg] = useState(
+    'https://mandarin.api.weniv.co.kr/1671431659709.png',
+  );
+  const [userName, setUserName] = useState('');
+  const [validUserName, setValidUserName] = useState('false');
+  console.log(validUserName);
+  const [errUserNameMsg, setErrUserNameMsg] = useState('');
 
   const handleImgUpload = async (e) => {
     let form = new FormData();
+
     form.append('image', e.target.files[0]);
-    console.log(e.target.files[0]);
+    if (e.target.files[0] === undefined) return;
 
     // 서버에 파일 전달
-    const response = await axiosImgUpload.post('/image/uploadfile', form);
-    console.log(response);
+    const {
+      data: { filename },
+    } = await axiosImgUpload.post('/image/uploadfile', form);
+
+    setProfileImg(`https://mandarin.api.weniv.co.kr/${filename}`);
   };
 
   useEffect(() => {
     if (!state?.email || !state?.password) navigate('/signup');
   }, []);
 
+  // 사용자 이름 유효성 체크
+  useEffect(() => {
+    const result = USERNAME_REGEX.test(userName);
+    setValidUserName(result);
+
+    if (!userName || result) {
+      setErrUserNameMsg('');
+    } else if (userName.length && !result) {
+      setErrUserNameMsg('2자~10자 이내여야 합니다.');
+    }
+  }, [userName]);
+
   return (
     <>
       <section>
         <h1>프로필 설정</h1>
         <p>나중에 언제든지 변경할 수 있습니다.</p>
-        <form>
+        <form autoComplete='off'>
           <div>
-            <label htmlFor='profileImg'>{/* <img src='' /> */}</label>
+            <label htmlFor='profileImg' style={{ cursor: 'pointer' }}>
+              <img src={profileImg} alt='' width='110px' height='110px' />
+            </label>
             <input
               id='profileImg'
               type='file'
               accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
               onChange={handleImgUpload}
+              style={{ display: 'none' }}
             />
           </div>
           <div>
             <label htmlFor='userName'>사용자 이름</label> <br />
-            <input id='userName' placeholder='2~10자 이내여야 합니다.' />
+            <input
+              id='userName'
+              placeholder='2~10자 이내여야 합니다.'
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+            />
+            {errUserNameMsg && <p>{errUserNameMsg}</p>}
           </div>
           <div>
             <label htmlFor='accountId'>계정 ID</label> <br />

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -15,12 +15,13 @@ const SignupProfile = () => {
   const [userName, setUserName] = useState('');
   console.log('userName :' + !!userName);
   const [validUserName, setValidUserName] = useState('false');
-  console.log(validUserName);
   const [errUserNameMsg, setErrUserNameMsg] = useState('');
   const [accountName, setAccountName] = useState('');
   const [validAccountName, setValidAccountName] = useState('false');
-  console.log(validAccountName);
   const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
+
+  // 가입 버튼 활성화 처리
+  const canSignup = validUserName && validAccountName;
 
   const handleImgUpload = async (e) => {
     let form = new FormData();
@@ -111,7 +112,7 @@ const SignupProfile = () => {
             <label htmlFor='introduce'>소개</label> <br />
             <input id='introduce' placeholder='자신에 대해 소개해 주세요!' />
           </div>
-          <button disabled>1n마켓 시작하기</button>
+          <button disabled={!canSignup}>1n마켓 시작하기</button>
         </form>
       </section>
     </>

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -4,13 +4,43 @@ import { useLocation, useNavigate } from 'react-router-dom';
 const SignupProfile = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
-  console.log(state);
 
   useEffect(() => {
     if (!state?.email || !state?.password) navigate('/signup');
   }, []);
 
-  return <div>index</div>;
+  return (
+    <>
+      <section>
+        <h1>프로필 설정</h1>
+        <p>나중에 언제든지 변경할 수 있습니다.</p>
+        <form>
+          <div>
+            <label htmlFor='profileImg'>
+              <img src='' />
+            </label>
+            <input id='profileImg' type='file' placeholder='파일등록' />
+          </div>
+          <div>
+            <label htmlFor='userName'>사용자 이름</label> <br />
+            <input id='userName' placeholder='2~10자 이내여야 합니다.' />
+          </div>
+          <div>
+            <label htmlFor='accountId'>계정 ID</label> <br />
+            <input
+              id='accountId'
+              placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+            />
+          </div>
+          <div>
+            <label htmlFor='introduce'>소개</label> <br />
+            <input id='introduce' placeholder='자신에 대해 소개해 주세요!' />
+          </div>
+          <button>1n마켓 시작하기</button>
+        </form>
+      </section>
+    </>
+  );
 };
 
 export default SignupProfile;


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [x] 신규 기능 추가 : 프로필 설정 기능 구현 (회원가입 두번째 페이지)
- [ ] 버그 수정 :
- [x] 리펙토링 : 이메일로 회원가입 페이지 로직 수정, 프로필 입력 폼 컴포넌트화 
- [ ] 디자인 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
- 프로필 입력 폼 작업
- 프로필 사진파일 등록
- 계정 ID 중복검사
- 사용자 이름 유효성 체크
- 회원가입 버튼 활성화 조건 처리
- 회원가입 처리 기능 구현
- 회원가입 성공시 로그인 페이지로 이동

## 💻 작업내용

1. 이메일로 회원가입 페이지
![signup_email](https://user-images.githubusercontent.com/104605709/209092247-d709d20e-2e5a-458d-a691-de6ab41a4b0f.gif)

2. 프로필 설정 페이지
![signup_profile](https://user-images.githubusercontent.com/104605709/209092834-8cff6159-cc5e-4728-b45e-1d6b08f4be36.gif)

3. 회원가입 잘 됐는지 체크!
![login_check](https://user-images.githubusercontent.com/104605709/209092894-fb75d7f9-2466-4f9b-89ef-8e1bcd2d7788.gif)

## 😉 전달사항
- 이메일로 회원가입 focus시 하단 컬러 변경되는 부분은 UI 구현할 때 리팩토링 할 예정입니다!
