### PR TITLE
[design] signup_회원가입 페이지 UI 구현(두번째 페이지) #62

### DIFF
--- a/src/assets/icons/upload-file.svg
+++ b/src/assets/icons/upload-file.svg
@@ -1,0 +1,6 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="25" cy="25" r="25" fill="#495573"/>
+<path d="M33.1667 14.5H16.8333C15.5447 14.5 14.5 15.5447 14.5 16.8333V33.1667C14.5 34.4553 15.5447 35.5 16.8333 35.5H33.1667C34.4553 35.5 35.5 34.4553 35.5 33.1667V16.8333C35.5 15.5447 34.4553 14.5 33.1667 14.5Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.9167 22.6667C21.8832 22.6667 22.6667 21.8832 22.6667 20.9167C22.6667 19.9502 21.8832 19.1667 20.9167 19.1667C19.9502 19.1667 19.1667 19.9502 19.1667 20.9167C19.1667 21.8832 19.9502 22.6667 20.9167 22.6667Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M35.4999 28.5L29.6666 22.6667L16.8333 35.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -121,38 +121,44 @@ const UserProfileForm = ({
             className='ir'
           />
         </S.FileWrapper>
-        <div>
-          <label htmlFor='userName'>사용자 이름</label> <br />
-          <input
+        <S.InputWrapper length='16px'>
+          <S.ProfileLabel htmlFor='userName'>사용자 이름</S.ProfileLabel>
+          <S.ProfileInput
             id='userName'
-            placeholder='2~10자의 한글,영어,숫자만 사용 가능'
+            placeholder='2~10자의 한글,영어,숫자만 사용 가능합니다.'
             maxLength='10'
             value={username}
             onChange={(e) => setUsername(e.target.value)}
           />
-          {errUserNameMsg && <p>{errUserNameMsg}</p>}
-        </div>
-        <div>
-          <label htmlFor='accountName'>계정 ID</label> <br />
-          <input
+          {errUserNameMsg && (
+            <S.ErrMsg dupcheck={validUserName}>{errUserNameMsg}</S.ErrMsg>
+          )}
+        </S.InputWrapper>
+        <S.InputWrapper length='16px'>
+          <S.ProfileLabel htmlFor='accountName'>계정 ID</S.ProfileLabel>
+          <S.ProfileInput
             id='accountName'
-            placeholder='영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능'
+            placeholder='영문 소문자,숫자, 특수문자(.),(_)만 사용 가능합니다.'
             maxLength='15'
             value={accountname}
             onChange={(e) => setAccountname(e.target.value)}
             onBlur={handleDupAccountName}
           />
-          {errAccountNameMsg && <p>{errAccountNameMsg}</p>}
-        </div>
-        <div>
-          <label htmlFor='introduce'>소개</label> <br />
-          <input
+          {errAccountNameMsg && (
+            <S.ErrMsg dupcheck={validDupAccountName}>
+              {errAccountNameMsg}
+            </S.ErrMsg>
+          )}
+        </S.InputWrapper>
+        <S.InputWrapper length='30px'>
+          <S.ProfileLabel htmlFor='introduce'>소개</S.ProfileLabel>
+          <S.ProfileInput
             id='introduce'
             placeholder='간단한 자기소개를 적어주세요!'
             value={intro}
             onChange={(e) => setIntro(e.target.value)}
           />
-        </div>
+        </S.InputWrapper>
       </S.ProfileForm>
     </>
   );

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -90,6 +90,9 @@ const UserProfileForm = ({
     if (username.length && !result) {
       setErrUserNameMsg('2~10자의 한글,영어,숫자만 사용 가능합니다.');
       setValidAccountName(false);
+    } else if (!username) {
+      setErrUserNameMsg('');
+      setValidAccountName(false);
     } else {
       setErrUserNameMsg('');
       setValidAccountName(true);

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -131,7 +131,7 @@ const UserProfileForm = ({
             onChange={(e) => setUsername(e.target.value)}
           />
           {errUserNameMsg && (
-            <S.ErrMsg dupcheck={validUserName}>{errUserNameMsg}</S.ErrMsg>
+            <S.ErrMsg validcheck={validUserName}>{errUserNameMsg}</S.ErrMsg>
           )}
         </S.InputWrapper>
         <S.InputWrapper length='16px'>
@@ -145,7 +145,7 @@ const UserProfileForm = ({
             onBlur={handleDupAccountName}
           />
           {errAccountNameMsg && (
-            <S.ErrMsg dupcheck={validDupAccountName}>
+            <S.ErrMsg validcheck={validDupAccountName}>
               {errAccountNameMsg}
             </S.ErrMsg>
           )}

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { axiosImgUpload, axiosPrivate } from '../../../apis/axios';
+import * as S from './style';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
 // eslint-disable-next-line
@@ -107,24 +108,19 @@ const UserProfileForm = ({
 
   return (
     <>
-      <form>
-        <div>
-          <label htmlFor='profileImg' style={{ cursor: 'pointer' }}>
-            <img
-              src={profileImg}
-              alt='프로필 사진'
-              width='110px'
-              height='110px'
-            />
-          </label>
+      <S.ProfileForm>
+        <S.FileWrapper>
+          <S.FileLabel htmlFor='profileImg'>
+            <S.ProfileImg src={profileImg} alt='프로필 사진' />
+          </S.FileLabel>
           <input
             id='profileImg'
             type='file'
             accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
             onChange={handleImgUpload}
-            style={{ display: 'none' }}
+            className='ir'
           />
-        </div>
+        </S.FileWrapper>
         <div>
           <label htmlFor='userName'>사용자 이름</label> <br />
           <input
@@ -157,7 +153,7 @@ const UserProfileForm = ({
             onChange={(e) => setIntro(e.target.value)}
           />
         </div>
-      </form>
+      </S.ProfileForm>
     </>
   );
 };

--- a/src/components/user/UserProfileForm/style.js
+++ b/src/components/user/UserProfileForm/style.js
@@ -10,7 +10,7 @@ export const ProfileForm = styled.form`
 
 export const FileWrapper = styled.div`
   width: 100%;
-  margin-bottom: 16px;
+  margin-bottom: 30px;
 `;
 
 export const FileLabel = styled.label`
@@ -34,7 +34,54 @@ export const FileLabel = styled.label`
 `;
 
 export const ProfileImg = styled.img`
+  width: 110px;
+  height: 110px;
   object-fit: cover;
   border-radius: 50%;
   border: 1px solid ${theme.palette.border};
+`;
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  margin-bottom: ${(props) => props.length};
+`;
+
+export const ProfileLabel = styled.label`
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: ${theme.palette.mediumGray};
+  margin-bottom: 10px;
+  line-height: 15px;
+`;
+
+export const ProfileInput = styled.input`
+  width: 100%;
+  font-size: 14px;
+  border: none;
+  border-bottom: 1px solid ${theme.palette.border};
+  padding: 0 0 8px 0;
+  line-height: 14px;
+  outline: none;
+
+  &::placeholder {
+    font-weight: 400;
+    color: ${theme.palette.lightGray};
+  }
+
+  &:focus {
+    border-bottom: 1px solid ${theme.palette.primary};
+  }
+
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px #fff inset;
+  }
+`;
+
+export const ErrMsg = styled.p`
+  font-size: 12px;
+  font-weight: 500;
+  color: ${({ dupcheck }) =>
+    dupcheck ? theme.palette.primary : theme.palette.alarm};
+  margin-top: 6px;
 `;

--- a/src/components/user/UserProfileForm/style.js
+++ b/src/components/user/UserProfileForm/style.js
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import theme from '../../../styles/theme';
+import uploadIcon from '../../../assets/icons/upload-file.svg';
+
+export const ProfileForm = styled.form`
+  width: calc(100% - 70px);
+  display: flex;
+  flex-direction: column;
+`;
+
+export const FileWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 16px;
+`;
+
+export const FileLabel = styled.label`
+  display: block;
+  width: 110px;
+  height: 110px;
+  position: relative;
+  color: ${theme.palette.mediumGray};
+  cursor: pointer;
+  margin: 0 auto;
+
+  &::after {
+    position: absolute;
+    content: '';
+    width: 36px;
+    height: 36px;
+    bottom: 0;
+    right: 0;
+    background: url(${uploadIcon}) no-repeat center / 36px 36px;
+  }
+`;
+
+export const ProfileImg = styled.img`
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid ${theme.palette.border};
+`;

--- a/src/components/user/UserProfileForm/style.js
+++ b/src/components/user/UserProfileForm/style.js
@@ -81,7 +81,7 @@ export const ProfileInput = styled.input`
 export const ErrMsg = styled.p`
   font-size: 12px;
   font-weight: 500;
-  color: ${({ dupcheck }) =>
-    dupcheck ? theme.palette.primary : theme.palette.alarm};
+  color: ${({ validcheck }) =>
+    validcheck ? theme.palette.primary : theme.palette.alarm};
   margin-top: 6px;
 `;

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -21,8 +21,6 @@ const Signup = () => {
 
   // 버튼 활성화 조건 처리
   const canNext = validRegEmail && validPassword && validDupEmail;
-  console.log(validRegEmail, validPassword, validDupEmail);
-  console.log(password.length);
 
   // 이메일 중복검사
   const handleDupEmail = async () => {
@@ -118,9 +116,7 @@ const Signup = () => {
               ref={inputRef}
             />
             {errEmailMsg && (
-              <p style={{ color: validDupEmail ? '#495573' : '#EB7F5F' }}>
-                {errEmailMsg}
-              </p>
+              <S.ErrMsg styledd={validDupEmail}>{errEmailMsg}</S.ErrMsg>
             )}
           </S.InputWrapper>
 
@@ -133,14 +129,10 @@ const Signup = () => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
-            {errPasswordlMsg && <p>{errPasswordlMsg}</p>}
+            {errPasswordlMsg && <S.ErrMsg>{errPasswordlMsg}</S.ErrMsg>}
           </S.InputWrapper>
 
-          <S.NextButton
-            disabled={!canNext}
-            onClick={handleDupEmail}
-            style={{ background: canNext ? '#495573' : '#abb9d6' }}
-          >
+          <S.NextButton disabled={!canNext} onClick={handleDupEmail}>
             다음
           </S.NextButton>
         </S.SignupForm>

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -104,8 +104,8 @@ const Signup = () => {
         <S.Title>이메일로 회원가입</S.Title>
         <S.SignupForm onSubmit={handleSubmit}>
           <S.InputWrapper length='16px'>
-            <label htmlFor='email'>이메일</label>
-            <input
+            <S.SignupLabel htmlFor='email'>이메일</S.SignupLabel>
+            <S.SignupInput
               length='16px'
               id='email'
               type='text'
@@ -116,20 +116,22 @@ const Signup = () => {
               ref={inputRef}
             />
             {errEmailMsg && (
-              <S.ErrMsg styledd={validDupEmail}>{errEmailMsg}</S.ErrMsg>
+              <S.ErrMsg validcheck={validDupEmail}>{errEmailMsg}</S.ErrMsg>
             )}
           </S.InputWrapper>
 
           <S.InputWrapper length='30px'>
-            <label htmlFor='pwd'>비밀번호</label>
-            <input
+            <S.SignupLabel htmlFor='pwd'>비밀번호</S.SignupLabel>
+            <S.SignupInput
               id='pwd'
               type='password'
               placeholder='비밀번호를 설정해 주세요.'
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
-            {errPasswordlMsg && <S.ErrMsg>{errPasswordlMsg}</S.ErrMsg>}
+            {errPasswordlMsg && (
+              <S.ErrMsg validcheck={validPassword}>{errPasswordlMsg}</S.ErrMsg>
+            )}
           </S.InputWrapper>
 
           <S.NextButton disabled={!canNext} onClick={handleDupEmail}>

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -21,6 +21,8 @@ const Signup = () => {
 
   // 버튼 활성화 조건 처리
   const canNext = validRegEmail && validPassword && validDupEmail;
+  console.log(validRegEmail, validPassword, validDupEmail);
+  console.log(password.length);
 
   // 이메일 중복검사
   const handleDupEmail = async () => {
@@ -71,6 +73,9 @@ const Signup = () => {
     const result = PWD_REGEX.test(password);
     if (password.length && !result) {
       setErrPasswordMsg('비밀번호는 6자 이상이어야 합니다.');
+      setValidPassword(false);
+    } else if (!password) {
+      setErrPasswordMsg('');
       setValidPassword(false);
     } else {
       setErrPasswordMsg('');

--- a/src/pages/Signup/style.js
+++ b/src/pages/Signup/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from '../../styles/theme';
 
 export const SignupWrapper = styled.section`
   width: 100%;
@@ -29,7 +30,7 @@ export const InputWrapper = styled.div`
     width: 100%;
     font-size: 14px;
     border: none;
-    border-bottom: 1px solid ${({ theme }) => theme.palette.border};
+    border-bottom: 1px solid ${theme.palette.border};
     padding: 0 0 8px 0;
     line-height: 14px;
     outline: none;
@@ -39,26 +40,31 @@ export const InputWrapper = styled.div`
     display: block;
     font-size: 12px;
     font-weight: 500;
-    color: ${({ theme }) => theme.palette.mediumGray};
+    color: ${theme.palette.mediumGray};
     margin-bottom: 10px;
     line-height: 15px;
   }
 
   input::placeholder {
     font-weight: 400;
-    color: ${({ theme }) => theme.palette.lightGray};
+    color: ${theme.palette.lightGray};
   }
 
   input:focus {
-    border-bottom: 1px solid ${({ theme }) => theme.palette.primary};
+    border-bottom: 1px solid ${theme.palette.primary};
   }
 
-  p {
-    font-size: 12px;
-    font-weight: 500;
-    color: ${({ theme }) => theme.palette.alarm};
-    margin-top: 6px;
+  input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px #fff inset;
   }
+`;
+
+export const ErrMsg = styled.p`
+  font-size: 12px;
+  font-weight: 500;
+  color: ${({ styledd }) =>
+    styledd ? theme.palette.primary : theme.palette.alarm};
+  margin-top: 6px;
 `;
 
 export const NextButton = styled.button`
@@ -68,6 +74,8 @@ export const NextButton = styled.button`
   font-weight: 500;
   border-radius: 44px;
   border: none;
-  color: ${({ theme }) => theme.palette.white};
-  background-color: ${({ theme }) => theme.palette.disabled};
+  color: ${theme.palette.white};
+  background-color: ${({ disabled }) =>
+    disabled ? theme.palette.disabled : theme.palette.primary};
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 `;

--- a/src/pages/Signup/style.js
+++ b/src/pages/Signup/style.js
@@ -49,7 +49,7 @@ export const InputWrapper = styled.div`
     color: ${({ theme }) => theme.palette.lightGray};
   }
 
-  &:focus {
+  input:focus {
     border-bottom: 1px solid ${({ theme }) => theme.palette.primary};
   }
 

--- a/src/pages/Signup/style.js
+++ b/src/pages/Signup/style.js
@@ -25,36 +25,36 @@ export const SignupForm = styled.form`
 export const InputWrapper = styled.div`
   width: 100%;
   margin-bottom: ${(props) => props.length};
+`;
 
-  input {
-    width: 100%;
-    font-size: 14px;
-    border: none;
-    border-bottom: 1px solid ${theme.palette.border};
-    padding: 0 0 8px 0;
-    line-height: 14px;
-    outline: none;
-  }
+export const SignupLabel = styled.label`
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: ${theme.palette.mediumGray};
+  margin-bottom: 10px;
+  line-height: 15px;
+`;
 
-  label {
-    display: block;
-    font-size: 12px;
-    font-weight: 500;
-    color: ${theme.palette.mediumGray};
-    margin-bottom: 10px;
-    line-height: 15px;
-  }
+export const SignupInput = styled.input`
+  width: 100%;
+  font-size: 14px;
+  border: none;
+  border-bottom: 1px solid ${theme.palette.border};
+  padding: 0 0 8px 0;
+  line-height: 14px;
+  outline: none;
 
-  input::placeholder {
+  &::placeholder {
     font-weight: 400;
     color: ${theme.palette.lightGray};
   }
 
-  input:focus {
+  &:focus {
     border-bottom: 1px solid ${theme.palette.primary};
   }
 
-  input:-webkit-autofill {
+  &:-webkit-autofill {
     -webkit-box-shadow: 0 0 0 1000px #fff inset;
   }
 `;
@@ -62,8 +62,8 @@ export const InputWrapper = styled.div`
 export const ErrMsg = styled.p`
   font-size: 12px;
   font-weight: 500;
-  color: ${({ styledd }) =>
-    styledd ? theme.palette.primary : theme.palette.alarm};
+  color: ${({ validcheck }) =>
+    validcheck ? theme.palette.primary : theme.palette.alarm};
   margin-top: 6px;
 `;
 

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import UserProfileForm from '../../components/user/UserProfileForm';
 import { axiosPrivate } from '../../apis/axios';
+import * as S from './style';
 
 const SignupProfile = () => {
   const { state } = useLocation();
@@ -39,9 +40,9 @@ const SignupProfile = () => {
 
   return (
     <>
-      <section>
-        <h2>프로필 설정</h2>
-        <p>나중에 언제든지 변경할 수 있습니다.</p>
+      <S.SignupWrapper>
+        <S.Title>프로필 설정</S.Title>
+        <S.Desc>나중에 언제든지 변경할 수 있습니다.</S.Desc>
         <UserProfileForm
           canSignup={canSignup}
           setCanSignup={setCanSignup}
@@ -55,10 +56,10 @@ const SignupProfile = () => {
           profileImg={profileImg}
           setProfileImg={setProfileImg}
         />
-        <button disabled={!canSignup} onClick={handleUserSignup}>
+        <S.SignupButton disabled={!canSignup} onClick={handleUserSignup}>
           1n마켓 시작하기
-        </button>
-      </section>
+        </S.SignupButton>
+      </S.SignupWrapper>
     </>
   );
 };

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -40,7 +40,7 @@ const SignupProfile = () => {
   return (
     <>
       <section>
-        <h1>프로필 설정</h1>
+        <h2>프로필 설정</h2>
         <p>나중에 언제든지 변경할 수 있습니다.</p>
         <UserProfileForm
           canSignup={canSignup}

--- a/src/pages/SignupProfile/style.js
+++ b/src/pages/SignupProfile/style.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import theme from '../../styles/theme';
+
+export const SignupWrapper = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const Title = styled.h2`
+  text-align: center;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 30px;
+  margin: 30px 0 12px 0;
+`;
+
+export const Desc = styled.p`
+  text-align: center;
+  font-size: 14px;
+  color: ${({ theme }) => theme.palette.mediumGray};
+`;
+
+export const SignupButton = styled.button`
+  width: 100%;
+  height: 44px;
+  font-size: 15px;
+  font-weight: 500;
+  border-radius: 44px;
+  border: none;
+  color: ${({ theme }) => theme.palette.white};
+  background-color: ${({ disabled }) =>
+    disabled ? theme.palette.disabled : theme.palette.primary};
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+`;

--- a/src/pages/SignupProfile/style.js
+++ b/src/pages/SignupProfile/style.js
@@ -19,6 +19,7 @@ export const Title = styled.h2`
 export const Desc = styled.p`
   text-align: center;
   font-size: 14px;
+  margin-bottom: 30px;
   color: ${({ theme }) => theme.palette.mediumGray};
 `;
 

--- a/src/pages/SignupProfile/style.js
+++ b/src/pages/SignupProfile/style.js
@@ -24,7 +24,7 @@ export const Desc = styled.p`
 `;
 
 export const SignupButton = styled.button`
-  width: 100%;
+  width: calc(100% - 70px);
   height: 44px;
   font-size: 15px;
   font-weight: 500;


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [ ] 신규 기능 추가 : 
- [x] 버그 수정 : 비밀번호 input 빈값일 때 버튼 활성화 오류 수정
- [x] 리펙토링
   - 이메일로 회원가입 페이지 props 조건처리 styled component로 이전
   - 이메일로 회원가입 페이지 input styled component로 변경
- [x] 디자인 : 회원가입 프로필 정보 등록 UI 페이지 구현
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
 - 회원가입 페이지 - 프로필 정보 등록 UI 페이지 구현
 - 프로필 정보 폼 컴포넌트 스타일링
 - (리팩토링) 이메일로 회원가입 페이지 border 컬러 처리
 - (리팩토링) 이메일로 회원가입 페이지 props 조건처리 styled component로 이전
 - (리팩토링) 이메일로 회원가입 페이지 input styled component로 변경
 - (fix) 비밀번호 input 빈값일 때 버튼 활성화 오류 수정

## 💻 작업내용
![signup_1](https://user-images.githubusercontent.com/104605709/209465917-50a0ff7f-c9f0-4a5a-a7aa-20e79d73a556.gif)
![signup_2](https://user-images.githubusercontent.com/104605709/209465919-356ec462-4504-4dbf-beef-807fd0a91e29.gif)


## 😉 전달사항

- 피그마에는 표현을 안해뒀는데, 유효성 검사시 true와 false 메세지 컬러가 다른게 명확할 것 같아서 해당 부분 수정했습니다. (true : primary컬러, false: alarm컬러)
- 이메일 회원가입에서 비밀번호 input이 빈값이어도 email 조건이 충족되면 버튼 활성화되는 오류 발견하여 조건식 하나 더 추가했습니다.
