### PR TITLE
[feat] profile_프로필 수정 페이지 기능 구현 #67

### DIFF
--- a/src/components/profile/ProfileInfo/index.jsx
+++ b/src/components/profile/ProfileInfo/index.jsx
@@ -11,7 +11,8 @@ const ProfileInfo = () => {
   const [profile, setProfile] = useState({});
   const [isLoading, setIsLoading] = useState(false);
 
-  const { followerCount, followingCount, image, intro, isfollow, username } = profile;
+  const { followerCount, followingCount, image, intro, isfollow, username } =
+    profile;
 
   useEffect(() => {
     const getUserInfo = async () => {
@@ -30,12 +31,16 @@ const ProfileInfo = () => {
       : false;
 
   const handleFollow = async () => {
-    const { data: { profile } } = await axiosPrivate.post(`/profile/${accountname}/follow`);
+    const {
+      data: { profile },
+    } = await axiosPrivate.post(`/profile/${accountname}/follow`);
     setProfile(profile);
   };
 
   const handleUnfollow = async () => {
-    const { data: { profile }} = await axiosPrivate.delete(`/profile/${accountname}/unfollow`);
+    const {
+      data: { profile },
+    } = await axiosPrivate.delete(`/profile/${accountname}/unfollow`);
     setProfile(profile);
   };
 
@@ -48,10 +53,7 @@ const ProfileInfo = () => {
           <S.Count>{followerCount}</S.Count>
           <S.CountInfo>followers</S.CountInfo>
         </S.CustomLink>
-        <S.ProfileImg
-          src={image}
-          alt={`${accountname}의 프로필 사진`}
-        />
+        <S.ProfileImg src={image} alt={`${accountname}의 프로필 사진`} />
 
         <S.CustomLink to={`followings`}>
           <S.Count>{followingCount}</S.Count>
@@ -66,7 +68,7 @@ const ProfileInfo = () => {
       <S.ButtonWrapper>
         {isMyProfile ? (
           <>
-            <Link to='edit'>
+            <Link to='edit' state={{ image, username, accountname, intro }}>
               <S.MyProfileButton>프로필 수정</S.MyProfileButton>
             </Link>
             <Link to='product'>
@@ -79,17 +81,11 @@ const ProfileInfo = () => {
               <MessageIcon />
             </S.IconButton>
             {isfollow ? (
-              <S.YourProfileButton
-                onClick={handleUnfollow}
-                isfollow={isfollow}
-              >
+              <S.YourProfileButton onClick={handleUnfollow} isfollow={isfollow}>
                 언팔로우
               </S.YourProfileButton>
             ) : (
-              <S.YourProfileButton
-                onClick={handleFollow}
-                isfollow={isfollow}
-              >
+              <S.YourProfileButton onClick={handleFollow} isfollow={isfollow}>
                 팔로우
               </S.YourProfileButton>
             )}

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -7,7 +7,7 @@ const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
 const ACCOUNTNAME_REGEX = /^[a-z0-9\.\_]{2,15}$/;
 
 const UserProfileForm = ({
-  setCanSignup,
+  setCanSave,
   username,
   setUsername,
   accountname,
@@ -101,7 +101,7 @@ const UserProfileForm = ({
   }, [username]);
 
   useEffect(() => {
-    setCanSignup(validUserName && validAccountName & validDupAccountName);
+    setCanSave(validUserName && validAccountName & validDupAccountName);
   }, [validUserName, validAccountName, validDupAccountName]);
 
   // 회원가입처리

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -76,9 +76,9 @@ const UserProfileForm = ({
   // 계정 ID 유효성 체크
   useEffect(() => {
     const result = ACCOUNTNAME_REGEX.test(accountname);
-    setValidDupAccountName(false);
 
     if (accountname.length && !result) {
+      setValidDupAccountName(false);
       setErrAccountNameMsg(
         '영문 소문자,숫자와 특수문자 마침표(.),밑줄(_)만 사용 가능합니다.',
       );

--- a/src/components/user/UserProfileForm/index.jsx
+++ b/src/components/user/UserProfileForm/index.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { axiosImgUpload, axiosPrivate } from '../../../apis/axios';
 import * as S from './style';
 
-const USERNAME_REGEX = /^[a-zA-Z0-9가-힣]{2,10}$/;
+const USERNAME_REGEX = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{2,10}$/;
 // eslint-disable-next-line
 const ACCOUNTNAME_REGEX = /^[a-z0-9\.\_]{2,15}$/;
 
@@ -17,11 +18,15 @@ const UserProfileForm = ({
   profileImg,
   setProfileImg,
 }) => {
+  const { pathname } = useLocation();
   const [validUserName, setValidUserName] = useState(false);
   const [errUserNameMsg, setErrUserNameMsg] = useState('');
   const [validAccountName, setValidAccountName] = useState(false);
-  const [validDupAccountName, setValidDupAccountName] = useState(false);
+  const [validDupAccountName, setValidDupAccountName] = useState(
+    pathname.includes('/edit') ? true : false,
+  );
   const [errAccountNameMsg, setErrAccountNameMsg] = useState('');
+  const userAccountname = JSON.parse(localStorage.getItem('accountname')) || '';
 
   const handleImgUpload = async (e) => {
     if (!e.target.files[0]) return;
@@ -38,7 +43,7 @@ const UserProfileForm = ({
 
   // 계정 ID 중복확인
   const handleDupAccountName = async () => {
-    if (validAccountName === true) {
+    if (validAccountName === true && userAccountname !== accountname) {
       try {
         const { data } = await axiosPrivate.post(
           `/user/accountnamevalid`,
@@ -61,16 +66,17 @@ const UserProfileForm = ({
       } catch (error) {
         console.error('err');
       }
+    } else if (userAccountname === accountname) {
+      setValidDupAccountName(true);
     } else {
       setValidDupAccountName(false);
-      return;
     }
   };
 
   // 계정 ID 유효성 체크
   useEffect(() => {
-    setValidDupAccountName(false);
     const result = ACCOUNTNAME_REGEX.test(accountname);
+    setValidDupAccountName(false);
 
     if (accountname.length && !result) {
       setErrAccountNameMsg(

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -5,7 +5,6 @@ import UserProfileForm from '../../components/user/UserProfileForm';
 
 const ProfileModify = () => {
   const { state } = useLocation();
-  console.log(state);
   const [profileImg, setProfileImg] = useState(state.image || '');
   const [username, setUsername] = useState(state.username || '');
   const [accountname, setAccountname] = useState(state.accountname || '');

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -1,17 +1,36 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { axiosPrivate } from '../../apis/axios';
 import SaveHeader from '../../components/common/Header/SaveHeader';
 import UserProfileForm from '../../components/user/UserProfileForm';
 
 const ProfileModify = () => {
   const { state } = useLocation();
+  const navigate = useNavigate();
   const [profileImg, setProfileImg] = useState(state.image || '');
   const [username, setUsername] = useState(state.username || '');
   const [accountname, setAccountname] = useState(state.accountname || '');
   const [intro, setIntro] = useState(state.intro || '');
   const [canSave, setCanSave] = useState(false);
 
-  const handleProductUpload = async (e) => {};
+  const handleProductUpload = async (e) => {
+    e.preventDefault();
+    if (!canSave) return;
+    await axiosPrivate.put(
+      '/user',
+      JSON.stringify({
+        user: {
+          username,
+          accountname,
+          intro,
+          image: profileImg,
+        },
+      }),
+    );
+    localStorage.setItem('accountname', JSON.stringify(accountname));
+    localStorage.setItem('profile-img', JSON.stringify(profileImg));
+    navigate(`/profile/${accountname}`);
+  };
 
   return (
     <>

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ProfileModify = () => {
+  return <div>프로필 수정페이지</div>;
+};
+
+export default ProfileModify;

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -12,9 +12,11 @@ const ProfileModify = () => {
   const [intro, setIntro] = useState(state.intro || '');
   const [canSave, setCanSave] = useState(false);
 
+  const handleProductUpload = async (e) => {};
+
   return (
     <>
-      <SaveHeader />
+      <SaveHeader canSave={canSave} handleProductUpload={handleProductUpload} />
       <UserProfileForm
         profileImg={profileImg}
         setProfileImg={setProfileImg}

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import SaveHeader from '../../components/common/Header/SaveHeader';
 import UserProfileForm from '../../components/user/UserProfileForm';
 
 const ProfileModify = () => {
-  const [profileImg, setProfileImg] = useState('');
-  const [username, setUsername] = useState('');
-  const [accountname, setAccountname] = useState('');
-  const [intro, setIntro] = useState('');
+  const { state } = useLocation();
+  console.log(state);
+  const [profileImg, setProfileImg] = useState(state.image || '');
+  const [username, setUsername] = useState(state.username || '');
+  const [accountname, setAccountname] = useState(state.accountname || '');
+  const [intro, setIntro] = useState(state.intro || '');
   const [canSave, setCanSave] = useState(false);
 
   return (

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import SaveHeader from '../../components/common/Header/SaveHeader';
 
 const ProfileModify = () => {
-  return <div>프로필 수정페이지</div>;
+  return (
+    <>
+      <SaveHeader />
+      <div>프로필 수정페이지</div>
+    </>
+  );
 };
 
 export default ProfileModify;

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -1,11 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SaveHeader from '../../components/common/Header/SaveHeader';
+import UserProfileForm from '../../components/user/UserProfileForm';
 
 const ProfileModify = () => {
+  const [profileImg, setProfileImg] = useState('');
+  const [username, setUsername] = useState('');
+  const [accountname, setAccountname] = useState('');
+  const [intro, setIntro] = useState('');
+  const [canSave, setCanSave] = useState(false);
+
   return (
     <>
       <SaveHeader />
-      <div>프로필 수정페이지</div>
+      <UserProfileForm
+        profileImg={profileImg}
+        setProfileImg={setProfileImg}
+        username={username}
+        setUsername={setUsername}
+        accountname={accountname}
+        setAccountname={setAccountname}
+        intro={intro}
+        setIntro={setIntro}
+        canSave={canSave}
+        setCanSave={setCanSave}
+      />
     </>
   );
 };

--- a/src/pages/ProfileModify/index.jsx
+++ b/src/pages/ProfileModify/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { axiosPrivate } from '../../apis/axios';
 import SaveHeader from '../../components/common/Header/SaveHeader';
@@ -7,10 +7,10 @@ import UserProfileForm from '../../components/user/UserProfileForm';
 const ProfileModify = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
-  const [profileImg, setProfileImg] = useState(state.image || '');
-  const [username, setUsername] = useState(state.username || '');
-  const [accountname, setAccountname] = useState(state.accountname || '');
-  const [intro, setIntro] = useState(state.intro || '');
+  const [profileImg, setProfileImg] = useState(state?.image || '');
+  const [username, setUsername] = useState(state?.username || '');
+  const [accountname, setAccountname] = useState(state?.accountname || '');
+  const [intro, setIntro] = useState(state?.intro || '');
   const [canSave, setCanSave] = useState(false);
 
   const handleProductUpload = async (e) => {
@@ -31,6 +31,10 @@ const ProfileModify = () => {
     localStorage.setItem('profile-img', JSON.stringify(profileImg));
     navigate(`/profile/${accountname}`);
   };
+
+  useEffect(() => {
+    if (!state) navigate('/home');
+  }, []);
 
   return (
     <>

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -13,7 +13,7 @@ const SignupProfile = () => {
   const [profileImg, setProfileImg] = useState(
     'https://mandarin.api.weniv.co.kr/1671431659709.png',
   );
-  const [canSignup, setCanSignup] = useState(false);
+  const [canSave, setCanSave] = useState(false);
 
   useEffect(() => {
     if (!state?.email || !state?.password) navigate('/signup');
@@ -21,7 +21,7 @@ const SignupProfile = () => {
 
   const handleUserSignup = async (e) => {
     e.preventDefault();
-    if (!canSignup) return;
+    if (!canSave) return;
     await axiosPrivate.post(
       '/user',
       JSON.stringify({
@@ -44,8 +44,8 @@ const SignupProfile = () => {
         <S.Title>프로필 설정</S.Title>
         <S.Desc>나중에 언제든지 변경할 수 있습니다.</S.Desc>
         <UserProfileForm
-          canSignup={canSignup}
-          setCanSignup={setCanSignup}
+          canSignup={canSave}
+          setCanSignup={setCanSave}
           handleUserSignup={handleUserSignup}
           username={username}
           setUsername={setUsername}
@@ -56,7 +56,7 @@ const SignupProfile = () => {
           profileImg={profileImg}
           setProfileImg={setProfileImg}
         />
-        <S.SignupButton disabled={!canSignup} onClick={handleUserSignup}>
+        <S.SignupButton disabled={!canSave} onClick={handleUserSignup}>
           1n마켓 시작하기
         </S.SignupButton>
       </S.SignupWrapper>

--- a/src/pages/SignupProfile/index.jsx
+++ b/src/pages/SignupProfile/index.jsx
@@ -44,8 +44,7 @@ const SignupProfile = () => {
         <S.Title>프로필 설정</S.Title>
         <S.Desc>나중에 언제든지 변경할 수 있습니다.</S.Desc>
         <UserProfileForm
-          canSignup={canSave}
-          setCanSignup={setCanSave}
+          setCanSave={setCanSave}
           handleUserSignup={handleUserSignup}
           username={username}
           setUsername={setUsername}

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -8,6 +8,7 @@ import Login from '../pages/Login';
 import PostUpload from '../pages/PostUpload';
 import ProdcutUpload from '../pages/ProductUpload';
 import Profile from '../pages/Profile';
+import ProfileModify from '../pages/ProfileModify';
 import Public from '../pages/Public';
 import Search from '../pages/Search';
 import Signup from '../pages/Signup';
@@ -39,12 +40,12 @@ const Router = () => {
               </Route>
 
               <Route path='search' element={<Search />} />
+            </Route>
 
-            </Route>
-            
             <Route path='post'>
-                <Route path='upload' element={<PostUpload />} />
+              <Route path='upload' element={<PostUpload />} />
             </Route>
+            <Route path='profile/:userId/edit' element={<ProfileModify />} />
           </Route>
 
           <Route path='*' element={<Missing />} />


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [x] 신규 기능 추가 : 내 프로필 수정 페이지 기능 구현(로그인 되어 있을 때)
- [ ] 버그 수정 :
- [x] 리펙토링 : 계정 ID 중복검사 로직 변경
- [x] 디자인 : 헤더 연결
- [ ] 문서 업데이트 :
- [x] 기타 : 버튼명 canSignup -> canSave로 변경

## 📋 작업사항
- 라우터에 프로필 수정 페이지 경로 등록
- 사용자 프로필 정보 받아오기
- 헤더 연결
- input 수정사항 발생시 저장하기 버튼 활성화처리
- 서버로 수정 정보 전달
- 수정 완료시 프로필 페이지로 이동 처리
- (refactor) 계정 ID 중복검사 로직 변경
- userProfilForm & signupProfile 버튼명 canSave로 변경

## 💻 작업내용
![profileModify](https://user-images.githubusercontent.com/104605709/209610299-a0e5688f-f9fd-4509-afc2-e927c04be714.gif)


## 😉 전달사항
기능 머지되는대로 디자인 작업 진행합니다!
