### PR TITLE
[refactor] profile&post_채팅&공유 버튼 깨짐 처리, 프로필 이미지 라운드 처리, 게시글 팝업창 변경 #85

### DIFF
--- a/src/assets/icons/icon-share.svg
+++ b/src/assets/icons/icon-share.svg
@@ -1,7 +1,7 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14 6.66663C15.3807 6.66663 16.5 5.54734 16.5 4.16663C16.5 2.78591 15.3807 1.66663 14 1.66663C12.6193 1.66663 11.5 2.78591 11.5 4.16663C11.5 5.54734 12.6193 6.66663 14 6.66663Z" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4 12.5C5.38071 12.5 6.5 11.3807 6.5 10C6.5 8.61929 5.38071 7.5 4 7.5C2.61929 7.5 1.5 8.61929 1.5 10C1.5 11.3807 2.61929 12.5 4 12.5Z" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14 18.3334C15.3807 18.3334 16.5 17.2141 16.5 15.8334C16.5 14.4527 15.3807 13.3334 14 13.3334C12.6193 13.3334 11.5 14.4527 11.5 15.8334C11.5 17.2141 12.6193 18.3334 14 18.3334Z" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.1582 11.2583L11.8499 14.575" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M11.8415 5.42505L6.1582 8.74172" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 6.66663C15.3807 6.66663 16.5 5.54734 16.5 4.16663C16.5 2.78591 15.3807 1.66663 14 1.66663C12.6193 1.66663 11.5 2.78591 11.5 4.16663C11.5 5.54734 12.6193 6.66663 14 6.66663Z" stroke="#767676" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 12.5C5.38071 12.5 6.5 11.3807 6.5 10C6.5 8.61929 5.38071 7.5 4 7.5C2.61929 7.5 1.5 8.61929 1.5 10C1.5 11.3807 2.61929 12.5 4 12.5Z" stroke="#767676" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 18.3334C15.3807 18.3334 16.5 17.2141 16.5 15.8334C16.5 14.4527 15.3807 13.3334 14 13.3334C12.6193 13.3334 11.5 14.4527 11.5 15.8334C11.5 17.2141 12.6193 18.3334 14 18.3334Z" stroke="#767676" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.1582 11.2583L11.8499 14.575" stroke="#767676" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.8415 5.42505L6.1582 8.74172" stroke="#767676" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/comment/CommentInput/style.js
+++ b/src/components/comment/CommentInput/style.js
@@ -21,6 +21,8 @@ export const InputSection = styled.section`
 export const ProfileImg = styled.img`
   width: 36px;
   height: 36px;
+  border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
 `;
 
 export const InputText = styled.input`

--- a/src/components/post/PostItem/index.jsx
+++ b/src/components/post/PostItem/index.jsx
@@ -64,7 +64,7 @@ const PostItem = ({ post, setPostsList }) => {
         <S.RightIcon onClick={() => setOpenModal(true)} />
       </S.PostArticle>
       {openModal &&
-        (accountname === post.author.username ? (
+        (accountname === post.author.accountname ? (
           <MyPostModal
             setOpenModal={setOpenModal}
             postId={post.id}

--- a/src/components/profile/FollowUser/style.js
+++ b/src/components/profile/FollowUser/style.js
@@ -4,19 +4,19 @@ import styled from 'styled-components';
 export const User = styled.li`
   ${({ theme }) => theme.common.flexSpaceBetween}
   padding: 8px 16px;
-`
+`;
 
 export const StyleLink = styled(Link)`
   text-decoration: none;
   display: flex;
   align-items: center;
-`
+`;
 
 export const UserImage = styled.img`
   width: 50px;
   height: 50px;
   border-radius: 50%;
-`
+`;
 
 export const UserInfo = styled.div`
   display: flex;
@@ -24,7 +24,7 @@ export const UserInfo = styled.div`
   justify-content: center;
   gap: 6px;
   margin-left: 12px;
-`
+`;
 
 export const UserName = styled.strong`
   color: ${({ theme }) => theme.palette.black};
@@ -44,7 +44,7 @@ export const UserIntro = styled.p`
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
-`
+`;
 
 export const FollowButton = styled.button`
   width: 56px;
@@ -52,5 +52,5 @@ export const FollowButton = styled.button`
   border-radius: 26px;
   font-weight: 400;
   font-size: 12px;
-  line-height: 15px
-`
+  line-height: 15px;
+`;

--- a/src/components/profile/ProductList/style.js
+++ b/src/components/profile/ProductList/style.js
@@ -28,8 +28,9 @@ export const ProductItem = styled.li`
   img {
     width: 140px;
     height: 90px;
-    border-radius: 8px;
     object-fit: cover;
+    border-radius: 8px;
+    border: 1px solid ${({ theme }) => theme.palette.border};
   }
 
   p {

--- a/src/components/profile/ProfileInfo/index.jsx
+++ b/src/components/profile/ProfileInfo/index.jsx
@@ -78,7 +78,13 @@ const ProfileInfo = () => {
         ) : (
           <>
             <S.IconButton>
-              <MessageIcon />
+              <MessageIcon
+                style={{
+                  width: '22px',
+                  height: '22px',
+                  margin: '3px 5px 3px 6px',
+                }}
+              />
             </S.IconButton>
             {isfollow ? (
               <S.YourProfileButton onClick={handleUnfollow} isfollow={isfollow}>
@@ -90,7 +96,13 @@ const ProfileInfo = () => {
               </S.YourProfileButton>
             )}
             <S.IconButton>
-              <ShareIcon />
+              <ShareIcon
+                style={{
+                  width: '20px',
+                  height: '20px',
+                  margin: '6px 5px',
+                }}
+              />
             </S.IconButton>
           </>
         )}

--- a/src/components/profile/ProfileInfo/style.js
+++ b/src/components/profile/ProfileInfo/style.js
@@ -39,6 +39,8 @@ export const CountInfo = styled.span`
 export const ProfileImg = styled.img`
   width: 110px;
   height: 110px;
+  border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
 `;
 
 export const Name = styled.strong`

--- a/src/components/profile/ProfileInfo/style.js
+++ b/src/components/profile/ProfileInfo/style.js
@@ -104,5 +104,7 @@ export const YourProfileButton = styled.button`
 export const IconButton = styled.button`
   background-color: ${({ theme }) => theme.palette.white};
   border: 1px solid ${({ theme }) => theme.palette.border};
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
 `;

--- a/src/pages/PostUpload/style.js
+++ b/src/pages/PostUpload/style.js
@@ -12,12 +12,14 @@ export const Conatiner = styled.main`
 export const ProfileImg = styled.img`
   width: 42px;
   height: 42px;
+  border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
 `;
 
 export const PostForm = styled.form`
   padding-top: 10px;
   width: 100%;
-`
+`;
 
 export const PostComment = styled.textarea`
   width: 100%;
@@ -37,7 +39,7 @@ export const ImgLabel = styled.label`
   justify-content: center;
   align-items: center;
   position: absolute;
-  bottom: 16px;;
+  bottom: 16px;
   right: 16px;
   width: 50px;
   height: 50px;


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [ ] 신규 기능 추가 : 
- [x] 버그 수정 : 내 게시글 팝업을 눌렀을 때 신고하기 -> 삭제/수정하기 팝업으로 변경
- [x] 리펙토링
  - 다른사람 프로필에서 팔로우 버튼 옆의 채팅/공유 버튼 깨짐 처리 수정
  - 프로필, 게시글, 댓글 작성의 사용자 이미지 라운드 처리
  - 판매중인 상품 이미지 border 처리해주기
- [ ] 디자인 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
 - 다른사람 프로필에서 팔로우 버튼 옆의 채팅/공유 버튼 깨짐 처리 수정 + 공유하기 아이콘 수정
- 프로필, 게시글, 댓글 작성의 사용자 이미지 라운드 처리
- 판매중인 상품 이미지 border 처리해주기
- 내 게시글 팝업을 눌렀을 때 신고하기 -> 삭제/수정하기 팝업으로 변경

## 💻 작업내용
-

## 😉 전달사항
- 공유하기 아이콘 라인이 다른 아이콘들보다 얇아보여서 두께 수정했습니다.