### PR TITLE
[feat] postmodify_게시글 수정하기 기능 구현

### DIFF
--- a/src/components/modals/MyPostModal/index.jsx
+++ b/src/components/modals/MyPostModal/index.jsx
@@ -4,7 +4,7 @@ import ModalLayout from '../ModalLayout';
 import PostRemoveModal from '../../alertModals/PostRemoveModal';
 import * as S from './style';
 
-const MyPostModal = ({ setOpenModal, postId, setPostsList }) => {
+const MyPostModal = ({ setOpenModal, postId, setPostsList, post }) => {
   const [openAelrt, setOpenAlert] = useState(false);
 
   return (
@@ -12,7 +12,7 @@ const MyPostModal = ({ setOpenModal, postId, setPostsList }) => {
       <ModalLayout setOpenModal={setOpenModal}>
         <li onClick={() => setOpenAlert(true)}>삭제</li>
         <li>
-          <S.PostEditLink to={`/post/${postId}/edit`}>수정</S.PostEditLink>
+          <S.PostEditLink to={`/post/${postId}/edit`} state={{ ...post }}>수정</S.PostEditLink>
         </li>
       </ModalLayout>
       {openAelrt && (

--- a/src/components/post/PostForm/index.jsx
+++ b/src/components/post/PostForm/index.jsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import * as S from './style';
+import { ReactComponent as UploadIcon } from '../../../assets/icons/icon-upload.svg';
+import { useRef } from 'react';
+import { axiosImgUpload } from '../../../apis/axios';
+
+
+const PostForm = ({content, setContent, imgFiles, setImgFiles}) => {
+
+  const textRef = useRef();
+
+  const autoResizeTextarea = (e) => {
+    textRef.current.style.height = 'auto';
+    let height = textRef.current.scrollHeight; // 높이
+    textRef.current.style.height = `${height + 16}px`;
+  };
+
+  const handleImgUpload = async (e) => {
+    e.preventDefault();
+    if (imgFiles.length > 2)
+      return window.alert('이미지는 세 개 이하로 업로드가 가능합니다!');
+    const form = new FormData();
+    form.append('image', e.target.files[0]);
+    const { data } = await axiosImgUpload.post('/image/uploadfile', form);
+
+    setImgFiles((prev) => [
+      ...prev,
+      `https://mandarin.api.weniv.co.kr/${data.filename}`,
+    ]);
+  };
+
+  const handleRemoveImg = (idx) => {
+    setImgFiles((prev) => prev.filter((_, i) => idx !== i));
+  }
+
+  return (
+    <S.Conatiner>
+        <S.ProfileImg
+          src={JSON.parse(localStorage.getItem('profile-img'))}
+          alt='사용자 이미지'
+        />
+        <S.PostForm>
+          <S.PostComment
+            ref={textRef}
+            value={content}
+            placeholder='게시글 입력하기...'
+            onChange={(e) => setContent(e.target.value)}
+            onKeyDown={autoResizeTextarea}
+            onKeyUp={autoResizeTextarea}
+          />
+          <S.ImgLabel htmlFor='img'>
+            <UploadIcon />
+          </S.ImgLabel>
+          <input
+            style={{ display: 'none' }}
+            id='img'
+            type='file'
+            accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
+            onChange={handleImgUpload}
+          />
+          <S.ImgList>
+            {imgFiles?.map((img, i) => (
+              <S.ImgItem key={img.slice(10)} >
+                <S.PostImg src={img} alt='' />
+                <S.RemoveButton type='button' onClick={() => handleRemoveImg(i)}>
+                  <span className='ir'>이미지 삭제</span>
+                </S.RemoveButton>
+              </S.ImgItem>
+            ))}
+          </S.ImgList>
+        </S.PostForm>
+      </S.Conatiner>
+  )
+}
+
+export default PostForm

--- a/src/components/post/PostForm/style.js
+++ b/src/components/post/PostForm/style.js
@@ -50,6 +50,7 @@ export const ImgLabel = styled.label`
 
 export const ImgList = styled.ul`
   width: 100%;
+  height: 10%;
   display: flex;
   gap: 8px;
   overflow-x: scroll;
@@ -61,11 +62,13 @@ export const ImgItem = styled.li`
   overflow: hidden;
   border: 0.5px solid ${({ theme }) => theme.palette.border};
   border-radius: 10px;
+  width: calc(100%/3);
 `;
 
 export const PostImg = styled.img`
   width: 100%;
   height: 100%;
+  object-fit: cover; 
 `;
 
 export const RemoveButton = styled.button`

--- a/src/components/post/PostForm/style.js
+++ b/src/components/post/PostForm/style.js
@@ -1,0 +1,95 @@
+import styled from 'styled-components';
+// import imgUpload from '../../assets/icons/icon-upload.svg';
+
+export const Conatiner = styled.main`
+  min-height: 100vh;
+  padding: 68px 16px 20px;
+  display: flex;
+  column-gap: 12px;
+  position: relative;
+`;
+
+export const ProfileImg = styled.img`
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
+`;
+
+export const PostForm = styled.form`
+  padding-top: 10px;
+  width: 100%;
+`;
+
+export const PostComment = styled.textarea`
+  width: 100%;
+  min-height: 16px;
+  margin-bottom: 16px;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden;
+`;
+
+export const ImgLabel = styled.label`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.palette.primary};
+  cursor: pointer;
+`;
+
+export const ImgList = styled.ul`
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  overflow-x: scroll;
+  overflow: hidden;
+`;
+
+export const ImgItem = styled.li`
+  position: relative;
+  overflow: hidden;
+  border: 0.5px solid ${({ theme }) => theme.palette.border};
+  border-radius: 10px;
+`;
+
+export const PostImg = styled.img`
+  width: 100%;
+  height: 100%;
+`;
+
+export const RemoveButton = styled.button`
+  position: absolute;
+  padding: 6px;
+  top: 10px;
+  right: 10px;
+  background-color: transparent;
+  border: none;
+
+  &::before,
+  &::after {
+    content: '';
+    width: 11px;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    transform: translateX(-50%);
+    border-bottom: 1px solid ${({ theme }) => theme.palette.white};
+  }
+  &::before {
+    transform: rotate(45deg);
+  }
+  &::after {
+    transform: rotate(-45deg);
+  }
+`;

--- a/src/components/post/PostItem/index.jsx
+++ b/src/components/post/PostItem/index.jsx
@@ -69,6 +69,7 @@ const PostItem = ({ post, setPostsList }) => {
             setOpenModal={setOpenModal}
             postId={post.id}
             setPostsList={setPostsList}
+            post={post}
           />
         ) : (
           <PostModal setOpenModal={setOpenModal} />

--- a/src/pages/PostModify/index.jsx
+++ b/src/pages/PostModify/index.jsx
@@ -1,10 +1,53 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { axiosPrivate } from '../../apis/axios';
+import UploadHeader from '../../components/common/Header/UploadHeader';
+import PostForm from '../../components/post/PostForm';
 
 const PostModify = () => {
+
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const { postId } = useParams();
+  const accountName = JSON.parse(localStorage.getItem('accountname'));
+
+  const [content, setContent] = useState(state?.content || '');
+  const [imgFiles, setImgFiles] = useState(!state?.image ? [] : state?.image.split(","));
+
+  const canSave = !!imgFiles.length || !!content;
+
+  const handlePostUpload = async (e) => {
+
+    e.preventDefault();
+    if (!canSave) return;
+    await axiosPrivate.put(
+      `/post/${postId}`,
+      JSON.stringify({
+        post: {
+          content,
+          image: imgFiles.join(','),
+        },
+      }),
+    );
+
+    navigate(`/profile/${accountName}`);
+  };
+
+  useEffect(() => {
+    if(!state) navigate('/home');
+  }, []);
+
   return (
-    <div>
-      
-    </div>
+    <>
+      <UploadHeader canSave={canSave} handlePostUpload={handlePostUpload} />
+      <PostForm 
+        content={content} 
+        setContent={setContent} 
+        imgFiles={imgFiles}
+        setImgFiles={setImgFiles}
+        />
+    </>
   )
 }
 

--- a/src/pages/PostModify/index.jsx
+++ b/src/pages/PostModify/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const PostModify = () => {
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default PostModify

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -1,38 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { axiosImgUpload, axiosPrivate } from '../../apis/axios';
+import { axiosPrivate } from '../../apis/axios';
 import UploadHeader from '../../components/common/Header/UploadHeader';
-import { ReactComponent as UploadIcon } from '../../assets/icons/icon-upload.svg';
-import * as S from './style';
-import { useRef } from 'react';
+import PostForm from '../../components/post/PostForm';
 
 const PostUpload = () => {
   const navigate = useNavigate();
   const [content, setContent] = useState('');
   const [imgFiles, setImgFiles] = useState([]);
-  const textRef = useRef();
 
   const canSave = !!imgFiles.length || !!content;
-
-  const handleImgUpload = async (e) => {
-    e.preventDefault();
-    if (imgFiles.length > 2)
-      return window.alert('이미지는 세 개 이하로 업로드가 가능합니다!');
-    const form = new FormData();
-    form.append('image', e.target.files[0]);
-    const { data } = await axiosImgUpload.post('/image/uploadfile', form);
-
-    setImgFiles((prev) => [
-      ...prev,
-      `https://mandarin.api.weniv.co.kr/${data.filename}`,
-    ]);
-  };
-
-  const autoResizeTextarea = (e) => {
-    textRef.current.style.height = 'auto';
-    let height = textRef.current.scrollHeight; // 높이
-    textRef.current.style.height = `${height + 16}px`;
-  };
 
   const handlePostUpload = async (e) => {
     console.log(content, imgFiles);
@@ -50,49 +27,15 @@ const PostUpload = () => {
     navigate('/home');
   };
 
-  const handleRemoveImg = (idx) => {
-    setImgFiles((prev) => prev.filter((_, i) => idx !== i));
-  }
-
   return (
     <>
       <UploadHeader canSave={canSave} handlePostUpload={handlePostUpload} />
-      <S.Conatiner>
-        <S.ProfileImg
-          src={JSON.parse(localStorage.getItem('profile-img'))}
-          alt='사용자 이미지'
+      <PostForm 
+        content={content} 
+        setcontent={setContent} 
+        imgFiles={imgFiles}
+        setImgFiles={setImgFiles}
         />
-        <S.PostForm>
-          <S.PostComment
-            ref={textRef}
-            value={content}
-            placeholder='게시글 입력하기...'
-            onChange={(e) => setContent(e.target.value)}
-            onKeyDown={autoResizeTextarea}
-            onKeyUp={autoResizeTextarea}
-          />
-          <S.ImgLabel htmlFor='img'>
-            <UploadIcon />
-          </S.ImgLabel>
-          <input
-            style={{ display: 'none' }}
-            id='img'
-            type='file'
-            accept='.jpg, .gif, .png, .jpeg, .bmp, .tif, .heic'
-            onChange={handleImgUpload}
-          />
-          <S.ImgList>
-            {imgFiles?.map((img, i) => (
-              <S.ImgItem key={img.slice(10)} >
-                <S.PostImg src={img} alt='' />
-                <S.RemoveButton type='button' onClick={() => handleRemoveImg(i)}>
-                  <span className='ir'>이미지 삭제</span>
-                </S.RemoveButton>
-              </S.ImgItem>
-            ))}
-          </S.ImgList>
-        </S.PostForm>
-      </S.Conatiner>
     </>
   );
 };

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -9,6 +9,8 @@ const PostUpload = () => {
   const [content, setContent] = useState('');
   const [imgFiles, setImgFiles] = useState([]);
 
+  console.log(imgFiles);
+
   const canSave = !!imgFiles.length || !!content;
 
   const handlePostUpload = async (e) => {
@@ -32,7 +34,7 @@ const PostUpload = () => {
       <UploadHeader canSave={canSave} handlePostUpload={handlePostUpload} />
       <PostForm 
         content={content} 
-        setcontent={setContent} 
+        setContent={setContent} 
         imgFiles={imgFiles}
         setImgFiles={setImgFiles}
         />

--- a/src/pages/PostUpload/index.jsx
+++ b/src/pages/PostUpload/index.jsx
@@ -9,8 +9,6 @@ const PostUpload = () => {
   const [content, setContent] = useState('');
   const [imgFiles, setImgFiles] = useState([]);
 
-  console.log(imgFiles);
-
   const canSave = !!imgFiles.length || !!content;
 
   const handlePostUpload = async (e) => {

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -17,6 +17,7 @@ import Missing from '../pages/Missing';
 import Post from '../pages/Post';
 import ProductModify from '../pages/ProductModify';
 import Chat from '../pages/Chat';
+import PostModify from '../pages/PostModify';
 
 const Router = () => {
   return (
@@ -49,7 +50,10 @@ const Router = () => {
 
             <Route path='post'>
               <Route path='upload' element={<PostUpload />} />
-              <Route path=':postId' element={<Post />} />
+              <Route path=':postId'>
+                <Route index element={<Post />} />
+                <Route path='edit' element={<PostModify />} />
+              </Route>
             </Route>
 
             <Route path='profile/:userId/edit' element={<ProfileModify />} />


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [x] 신규 기능 추가 : 게시물 수정 기능 구현
- [ ] 버그 수정 :
- [x] 리펙토링 : 수정페이시 마운트 시 이미지 파일 배치비율 스타일링
- [ ] 디자인 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
- pages 폴더 내 PostModify 폴더 및 파일 생성과 라우터 연결
- PostUpload 컴포넌트에서 form 부분을 다른 컴포넌트(PostForm)로 분리하기
- PostModify 페이지 게시글 수정하기 기능 구현(수정페이지 마운트 시 기존 데이터 불러오기 포함)
- 수정페이시 마운트 시 이미지 파일 배치비율 스타일링

## 💻 작업내용

- 게시물 수정 전 홈 화면

<img width="416" alt="스크린샷 2022-12-29 오후 5 26 31" src="https://user-images.githubusercontent.com/111214565/209925037-7d12304d-7fe5-49e0-9eb7-21fb6e4bda2c.png">


- 게시물 수정 페이지 마운트 시 화면

<img width="402" alt="스크린샷 2022-12-29 오후 5 27 11" src="https://user-images.githubusercontent.com/111214565/209925047-30c1ac52-5b7f-4f71-927e-77eff82bcd72.png">


- 게시물 수정 사항 반영 화면

<img width="420" alt="스크린샷 2022-12-29 오후 5 27 38" src="https://user-images.githubusercontent.com/111214565/209925061-745c832a-2319-47ed-92d6-0a3f0cc4ee5c.png">


- 수정된 게시물이 홈에 렌더링된 화면

<img width="409" alt="스크린샷 2022-12-29 오후 5 27 55" src="https://user-images.githubusercontent.com/111214565/209925065-725e9e2e-3aa3-4eb1-8072-f643ce60542e.png">

## 😉 전달사항
전달사항이 있으면 작성해주세요
