### PR TITLE
[refactor] layout_css 깨진 부분 수정 #97

### DIFF
--- a/src/components/comment/CommentInput/style.js
+++ b/src/components/comment/CommentInput/style.js
@@ -21,6 +21,7 @@ export const InputSection = styled.section`
 export const ProfileImg = styled.img`
   width: 36px;
   height: 36px;
+  object-fit: cover;
   border-radius: 50%;
   border: 1px solid ${({ theme }) => theme.palette.border};
 `;

--- a/src/components/post/PostAlbum/style.js
+++ b/src/components/post/PostAlbum/style.js
@@ -14,8 +14,9 @@ export const PostAlbumItem = styled.li`
 `;
 
 export const AlbumImg = styled.img`
-  width: 100%;
-  height: 100%;
+  width: 114px;
+  height: 114px;
+  object-fit: cover;
 `;
 
 export const ImageLayerIcon = styled(ImageLayer)`

--- a/src/components/post/PostForm/style.js
+++ b/src/components/post/PostForm/style.js
@@ -12,6 +12,7 @@ export const Conatiner = styled.main`
 export const ProfileImg = styled.img`
   width: 42px;
   height: 42px;
+  object-fit: cover;
   border-radius: 50%;
   border: 1px solid ${({ theme }) => theme.palette.border};
 `;
@@ -62,13 +63,13 @@ export const ImgItem = styled.li`
   overflow: hidden;
   border: 0.5px solid ${({ theme }) => theme.palette.border};
   border-radius: 10px;
-  width: calc(100%/3);
+  width: calc(100% / 3);
 `;
 
 export const PostImg = styled.img`
   width: 100%;
   height: 100%;
-  object-fit: cover; 
+  object-fit: cover;
 `;
 
 export const RemoveButton = styled.button`

--- a/src/components/post/PostItem/style.js
+++ b/src/components/post/PostItem/style.js
@@ -22,7 +22,9 @@ export const AuthorProfileLink = styled(Link)`
 export const AuthorImage = styled.img`
   width: 42px;
   height: 42px;
+  object-fit: cover;
   border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
 `;
 
 export const AuthorNameWrapper = styled.div`

--- a/src/components/post/ProductForm/style.js
+++ b/src/components/post/ProductForm/style.js
@@ -1,37 +1,36 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 import FindImgBtn from '../../../assets/icons/img-button.svg';
 
-
 export const Form = styled.form`
-    padding: 78px 34px 0px;
+  padding: 78px 34px 0px;
 `;
 
 export const ImgWrapper = styled.div`
-    padding-bottom: 30px;
+  padding-bottom: 30px;
 `;
 
 export const ImgUploadText = styled.p`
-    font-size: 12px;
-    color: ${({theme}) => theme.palette.mediumGray};
+  font-size: 12px;
+  color: ${({ theme }) => theme.palette.mediumGray};
 `;
 
 export const ProductImgDiv = styled.div`
-    width: 322px;
-    height: 204px;
-    margin-top: 18px;
-    border-radius: 10px;
-    position: relative;
-    background-color: ${({ theme }) => theme.palette.border};
+  width: 322px;
+  height: 204px;
+  margin-top: 18px;
+  border-radius: 10px;
+  position: relative;
+  background-color: ${({ theme }) => theme.palette.border};
 `;
 
 export const BtnImg = styled.img.attrs({
-    src: FindImgBtn,
-    alt: "이미지 업로드"
+  src: FindImgBtn,
+  alt: '이미지 업로드',
 })`
-    position: absolute;
-    right: 12px;
-    bottom: 12px;
-    cursor: pointer;
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  cursor: pointer;
 `;
 
 export const ProductImg = styled.img`
@@ -43,36 +42,43 @@ export const ProductImg = styled.img`
 `;
 
 export const InputWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    p {
-        font-size: 12px;
-        font-weight: 500;
-        color: ${({ theme }) => theme.palette.alarm};
-        margin: -10px 0 15px 0;
-      }
+  display: flex;
+  flex-direction: column;
+  p {
+    font-size: 12px;
+    font-weight: 500;
+    color: ${({ theme }) => theme.palette.alarm};
+    margin: -10px 0 15px 0;
+  }
 `;
 
 export const ProductInputLabel = styled.label`
-    color: ${({theme}) => theme.palette.mediumGray};
-    font-size: 12px;
+  color: ${({ theme }) => theme.palette.mediumGray};
+  font-size: 12px;
 `;
 
 export const ProductInput = styled.input`
-    display: block;
-    padding: 10px 0 8px 0;
-    margin-bottom: 16px;
-    border: none;
-    border-bottom: 1px solid ${({ theme }) => theme.palette.border};;
-    outline: none;
-    ::placeholder {
-        color: ${({ theme }) => theme.palette.border};
-    }
-    ::-webkit-outer-spin-button,
-    ::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-    }
-    &:focus {
-        border-bottom: 1px solid ${({ theme }) => theme.palette.primary};
-    }
+  display: block;
+  padding: 10px 0 8px 0;
+  margin-bottom: 16px;
+  border: none;
+  border-bottom: 1px solid ${({ theme }) => theme.palette.border};
+  outline: none;
+
+  ::placeholder {
+    color: ${({ theme }) => theme.palette.border};
+  }
+
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+
+  &:focus {
+    border-bottom: 1px solid ${({ theme }) => theme.palette.primary};
+  }
+
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px #fff inset;
+  }
 `;

--- a/src/components/profile/FollowUser/style.js
+++ b/src/components/profile/FollowUser/style.js
@@ -15,7 +15,9 @@ export const StyleLink = styled(Link)`
 export const UserImage = styled.img`
   width: 50px;
   height: 50px;
+  object-fit: cover;
   border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
 `;
 
 export const UserInfo = styled.div`

--- a/src/components/profile/ProductList/style.js
+++ b/src/components/profile/ProductList/style.js
@@ -38,6 +38,10 @@ export const ProductItem = styled.li`
     line-height: 18px;
     margin-top: 4px;
     margin-bottom: 2px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    word-break: break-all;
   }
 
   strong {

--- a/src/components/profile/ProfileInfo/style.js
+++ b/src/components/profile/ProfileInfo/style.js
@@ -39,6 +39,7 @@ export const CountInfo = styled.span`
 export const ProfileImg = styled.img`
   width: 110px;
   height: 110px;
+  object-fit: cover;
   border-radius: 50%;
   border: 1px solid ${({ theme }) => theme.palette.border};
 `;

--- a/src/components/search/SearchList/style.js
+++ b/src/components/search/SearchList/style.js
@@ -19,7 +19,9 @@ export const SearchItem = styled.li`
 export const UserImage = styled.img`
   width: 50px;
   height: 50px;
+  object-fit: cover;
   border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.palette.border};
 `;
 
 export const UserInfo = styled.div`

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from '../../apis/axios';
 import * as S from './style';
@@ -9,6 +9,7 @@ const Login = () => {
   const [errMsg, setErrMsg] = useState('');
   const navigate = useNavigate();
   const location = useLocation();
+  const inputRef = useRef();
 
   const from = location.state?.from?.pathname || '/';
 
@@ -51,6 +52,10 @@ const Login = () => {
     setErrMsg('');
   }, [email, password]);
 
+  useEffect(() => {
+    if (inputRef.current !== null) inputRef.current.focus();
+  }, []);
+
   return (
     <S.Container>
       <S.Title>로그인</S.Title>
@@ -60,6 +65,7 @@ const Login = () => {
           <S.LoginInput
             id='email'
             type='text'
+            ref={inputRef}
             onChange={(e) => setEmail(e.target.value)}
           />
         </S.InputWrapper>

--- a/src/pages/Login/style.js
+++ b/src/pages/Login/style.js
@@ -39,8 +39,13 @@ export const LoginInput = styled.input`
   padding: 5px 0;
   outline: none;
   border-bottom: 1px solid ${({ theme }) => theme.palette.border};
+
   &:focus {
     border-bottom: 1px solid ${({ theme }) => theme.palette.primary};
+  }
+
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px #fff inset;
   }
 `;
 


### PR DESCRIPTION
## ⭐️ 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [ ] 신규 기능 추가 : 게시물 이미지 업로드 삭제 기능
- [ ] 버그 수정 :
- [x] 리펙토링 : css 깨진 부분 수정
- [ ] 디자인 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 📋 작업사항
- [x] 프로필 이미지 배율
- [x] 검색결과 프로필 이미지 배율
- [x] 댓글입력 프로필 이미지 배율
- [x] 게시글 업로드 프로필 이미지 배율
- [x] 팔로워/팔로잉 프로필 이미지 배율
- [x] 로그인/게시글 수정페이지 자동저장 input 내용 클릭시 배경처리되는 부분
- [x] 상품 리스트 제목 한줄 이상이여도 그대로 출력되는 부분
- [x] 내 게시글 앨범보기 이미지 배율
- [x] (refactor) 로그인 페이지 첫 렌더링시 input 커서 포커싱처리

## 💻 작업내용
<img width="397" alt="스크린샷 2023-01-02 오후 12 58 39" src="https://user-images.githubusercontent.com/104605709/210194247-9bdb19e4-70e1-4108-abf9-f03d776d1c54.png">
<img width="411" alt="스크린샷 2023-01-02 오후 12 58 24" src="https://user-images.githubusercontent.com/104605709/210194253-e7308fd8-d4c0-4dec-a957-6a8ed28d3a78.png">

- 그외 프로필 이미지 배율이나 input 처리는 따로 이미지 첨부 안했습니다!


## 😉 전달사항
